### PR TITLE
Fix operation_type field in Inmuebles24 scraper

### DIFF
--- a/scrapers/inm24.py
+++ b/scrapers/inm24.py
@@ -182,7 +182,7 @@ class Inmuebles24ProfessionalScraper:
             'last_page': page_num,
             'properties_count': len(self.properties_data),
             'timestamp': datetime.now().isoformat(),
-            'operation_type': self.target_url
+            'operation_type': self.operation_type
         }
         
         try:
@@ -541,7 +541,7 @@ class Inmuebles24ProfessionalScraper:
                 'avg_time_per_page': avg_time_per_page,
                 'success_rate': success_rate,
                 'csv_file': csv_path,
-                'operation_type': self.target_url
+                'operation_type': self.operation_type
             }
             
             # Log final

--- a/tests/test_operation_type.py
+++ b/tests/test_operation_type.py
@@ -1,0 +1,21 @@
+import sys
+from pathlib import Path
+from datetime import datetime
+from unittest.mock import patch
+
+# Asegurar que el directorio raíz del proyecto está en sys.path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from scrapers.inm24 import Inmuebles24ProfessionalScraper
+
+
+def test_operation_type_matches_cli_option():
+    scraper = Inmuebles24ProfessionalScraper(operation_type='renta')
+    # Establecer start_time para evitar dependencias en scrape_pages original
+    scraper.start_time = datetime.now()
+
+    with patch.object(Inmuebles24ProfessionalScraper, 'scrape_pages', return_value=(0, 0)), \
+         patch.object(Inmuebles24ProfessionalScraper, 'save_results', return_value='dummy.csv'):
+        results = scraper.run()
+
+    assert results['operation_type'] == 'renta'


### PR DESCRIPTION
## Summary
- ensure `operation_type` field reflects CLI option in Inmuebles24 results and checkpoints
- add unit test validating `operation_type` matches the CLI argument

## Testing
- `pytest tests/test_operation_type.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b3e3e522008331a241c47c5112ba62