### PR TITLE
fix: update deployment references

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,20 +37,22 @@ PropertyScraper-Dell710/
 │   └── tro.py               # Trovit scraper
 ├── orchestrator/             # Sistema de orquestación concurrente
 │   ├── advanced_orchestrator.py
-│   ├── quick_launcher.py
-│   └── resource_monitor.py
+│   ├── bimonthly_scheduler.py
+│   └── concurrent_manager.py
 ├── utils/                    # Utilidades y herramientas
 │   ├── create_data_structure.py
-│   ├── ssh_connector.py
-│   └── data_validator.py
+│   ├── gdrive_backup_manager.py
+│   ├── md_to_docx.py
+│   ├── md_to_rtf.py
+│   ├── checkpoint_recovery.py
+│   ├── enhanced_scraps_registry.py
+│   ├── scraps_registry.py
+│   └── visual_terminal_monitor.py
 ├── config/                   # Configuraciones del sistema
 │   ├── dell_t710_config.yaml
-│   ├── Lista de URLs.csv    # Configuración central de URLs con jerarquía
 │   └── ssh_config.json
 ├── monitoring/               # Sistema de monitoreo
-│   ├── performance_monitor.py
-│   ├── error_handler.py
-│   └── progress_tracker.py
+│   └── performance_monitor.py
 ├── logs/                     # Logs del sistema
 ├── data/                     # Datos estructurados con nueva nomenclatura
 │   ├── inm24/               # Inmuebles24 data
@@ -64,9 +66,8 @@ PropertyScraper-Dell710/
 │   ├── prop/                # Propiedades data
 │   └── tro/                 # Trovit data
 ├── ssh_deployment/           # Scripts de despliegue SSH
-│   ├── deploy_to_dell710.py
-│   ├── remote_executor.py
-│   └── sync_results.py
+│   └── remote_executor.py
+├── URLs/                    # CSVs de URLs por sitio
 └── docs/                     # Documentación completa
 ```
 
@@ -150,10 +151,10 @@ data/inm24/venta/ago2025/1/
 ssh scraper@192.168.50.54
 
 # Ejecución de scraper específico
-python3 /home/scraper/PropertyScraper-Dell710/orchestrator/run_inmuebles24.py
+python3 /home/scraper/PropertyScraper-Dell710/scrapers/inm24.py --headless --pages=100
 
 # Monitoreo en tiempo real
-tail -f /home/scraper/PropertyScraper-Dell710/logs/progress_monitor.log
+tail -f /home/scraper/PropertyScraper-Dell710/logs/ssh_executor_*.log
 ```
 
 ## ⚙️ Configuración Dell T710
@@ -177,9 +178,9 @@ tail -f /home/scraper/PropertyScraper-Dell710/logs/progress_monitor.log
    python utils/create_data_structure.py
    ```
 
-2. **Configurar SSH**:
+2. **Despliegue remoto (opcional)**:
    ```bash
-   python ssh_deployment/setup_ssh_connection.py
+   python ssh_deployment/remote_executor.py --deploy
    ```
 
 3. **Ejecutar scraper individual**:
@@ -199,11 +200,6 @@ tail -f /home/scraper/PropertyScraper-Dell710/logs/progress_monitor.log
    python orchestrator/advanced_orchestrator.py
    ```
 
-5. **Launcher rápido para testeo**:
-   ```bash
-   python orchestrator/quick_launcher.py
-   ```
-
 ## 🏆 Resultados Probados
 
 ### Test exitoso - Inmuebles24 (`inm24.py`)
@@ -217,7 +213,7 @@ tail -f /home/scraper/PropertyScraper-Dell710/logs/progress_monitor.log
 - **8 Scrapers**: Todos funcionales con nueva nomenclatura
 - **SeleniumBase**: Configuración estandarizada y compatible
 - **Estructura de datos**: Optimizada con abreviaciones
-- **Lista de URLs.csv**: Configuración centralizada con jerarquía
+- **Directorio URLs/**: Configuración centralizada con jerarquía
 
 ---
 

--- a/quick_deploy.py
+++ b/quick_deploy.py
@@ -43,7 +43,7 @@ def main():
     print("\n📄 Verificando archivos principales...")
     
     key_files = [
-        'scrapers/inmuebles24_professional.py',
+        'scrapers/inm24.py',
         'orchestrator/concurrent_manager.py',
         'orchestrator/bimonthly_scheduler.py',
         'ssh_deployment/remote_executor.py',
@@ -73,13 +73,13 @@ def main():
         websites = list(data_dir.iterdir())
         print(f"✅ Estructura de datos creada: {len(websites)} sitios web")
         
-        # Verificar estructura de inmuebles24
-        inmuebles24_dir = data_dir / 'inmuebles24'
-        if inmuebles24_dir.exists():
-            operations = list(inmuebles24_dir.iterdir())
-            print(f"✅ inmuebles24: {len(operations)} tipos de operación")
+        # Verificar estructura de inm24
+        inm24_dir = data_dir / 'inm24'
+        if inm24_dir.exists():
+            operations = list(inm24_dir.iterdir())
+            print(f"✅ inm24: {len(operations)} tipos de operación")
         else:
-            print("❌ inmuebles24 directory missing")
+            print("❌ inm24 directory missing")
     else:
         print("❌ Estructura de datos no creada")
         print("Ejecute: python utils/create_data_structure.py")
@@ -91,7 +91,7 @@ def main():
     print("   pip install -r requirements.txt")
     
     print("\n🧪 2. Probar scraper local (5 páginas):")
-    print("   python scrapers/inmuebles24_professional.py --headless --pages=5")
+    print("   python scrapers/inm24.py --headless --pages=5")
     
     print("\n🌐 3. Desplegar en Dell T710:")
     print("   python ssh_deployment/remote_executor.py --deploy")


### PR DESCRIPTION
## Summary
- sync quick deployment script with current project layout
- remove stale references from README and document real modules

## Testing
- `python quick_deploy.py`
- `pytest` *(fails: fixture 'website' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3e3e9cfd08331b0d2dd020b6857df