### PR TITLE
Centralize URL list in config and update registry references

### DIFF
--- a/config/Lista de URLs.csv
+++ b/config/Lista de URLs.csv
@@ -1,0 +1,2 @@
+PaginaWeb,Estado,Ciudad,Operación,ProductoPaginaWeb,URL
+Inmuebles24,Jalisco,Zapopan,venta,Bodegas comerciales,https://www.inmuebles24.com/bodegas-comerciales-en-venta-en-zapopan.html

--- a/setup_inicial.py
+++ b/setup_inicial.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """
 Setup Inicial - PropertyScraper Dell710
-Script para configurar el sistema integrado con Lista de URLs.csv
+Script para configurar el sistema integrado con config/Lista de URLs.csv
 """
 
 import os
@@ -31,14 +31,14 @@ def setup_logging():
     return logging.getLogger(__name__)
 
 def check_csv_file():
-    """Verificar que Lista de URLs.csv existe y tiene la estructura correcta"""
+    """Verificar que config/Lista de URLs.csv existe y tiene la estructura correcta"""
     logger = logging.getLogger(__name__)
-    logger.info("📄 Verificando Lista de URLs.csv...")
-    
-    csv_path = Path('Lista de URLs.csv')
+    logger.info("📄 Verificando config/Lista de URLs.csv...")
+
+    csv_path = Path('config') / 'Lista de URLs.csv'
     
     if not csv_path.exists():
-        logger.error("❌ Lista de URLs.csv no encontrada")
+        logger.error("❌ config/Lista de URLs.csv no encontrada")
         logger.info("📋 Crear archivo Lista de URLs.csv con las columnas:")
         logger.info("   PaginaWeb,Estado,Ciudad,Operación,ProductoPaginaWeb,URL")
         return False
@@ -49,7 +49,7 @@ def check_csv_file():
             rows = list(reader)
         
         if not rows:
-            logger.error("❌ Lista de URLs.csv está vacía")
+            logger.error("❌ config/Lista de URLs.csv está vacía")
             return False
         
         # Verificar columnas requeridas
@@ -256,7 +256,7 @@ def setup_complete_check():
     logger.info("🔍 Verificación final del setup...")
     
     checks = [
-        ("Lista de URLs.csv", check_csv_file()),
+        ("config/Lista de URLs.csv", check_csv_file()),
         ("Dependencias Python", check_dependencies()),
         ("Scrapers", check_scrapers()),
         ("Registry", initialize_registry())

--- a/test_integration.py
+++ b/test_integration.py
@@ -53,19 +53,13 @@ def test_enhanced_registry():
         # Test obtener próximos scraps
         next_scraps = registry.get_next_scraps_to_run(10)
         logger.info(f"⏭️ Próximos scraps: {len(next_scraps)}")
-        
+
         if next_scraps:
             sample_scrap = next_scraps[0]
             logger.info(f"🎯 Ejemplo scrap: {sample_scrap['website']} - {sample_scrap['url']}")
-            
+
             # Test ruta de salida
-            output_path = registry.get_output_path(
-                sample_scrap['website'],
-                sample_scrap['state'],
-                sample_scrap['city'],
-                sample_scrap['operation'],
-                sample_scrap['product']
-            )
+            output_path = registry.get_output_path(sample_scrap)
             logger.info(f"📁 Ruta salida: {output_path}")
         
         logger.info("✅ EnhancedScrapsRegistry test exitoso")
@@ -162,7 +156,7 @@ def test_csv_structure():
     logger.info("🧪 Testing estructura Lista de URLs.csv...")
     
     try:
-        csv_path = Path('Lista de URLs.csv')
+        csv_path = Path('config') / 'Lista de URLs.csv'
         if not csv_path.exists():
             logger.error("❌ Lista de URLs.csv no encontrada")
             return False

--- a/utils/enhanced_scraps_registry.py
+++ b/utils/enhanced_scraps_registry.py
@@ -26,8 +26,8 @@ class EnhancedScrapsRegistry:
         self.progress_file = self.project_root / 'data' / 'scraps_progress.json'
         self.setup_logging()
         
-        # Cargar URLs desde el archivo CSV de Lista de URLs
-        self.csv_urls_file = self.project_root / 'Lista de URLs.csv'
+        # Cargar URLs desde el archivo CSV central ubicado en config/
+        self.csv_urls_file = self.project_root / 'config' / 'Lista de URLs.csv'
         self.urls_registry = self.load_urls_from_csv()
         
         # Mapeo de sitios web
@@ -225,6 +225,21 @@ class EnhancedScrapsRegistry:
         except Exception as e:
             self.logger.error(f"Error obteniendo scraps pendientes: {e}")
             return []
+
+    def get_next_scraps_to_run(self, max_count: int = 4) -> List[Dict]:
+        """Obtener los próximos scraps a ejecutar según prioridades"""
+        pending_scraps = self.get_pending_scraps()
+        selected_scraps: List[Dict] = []
+        used_websites = set()
+
+        for scrap in pending_scraps:
+            if len(selected_scraps) >= max_count:
+                break
+            if scrap['website'] not in used_websites:
+                selected_scraps.append(scrap)
+                used_websites.add(scrap['website'])
+
+        return selected_scraps
     
     def get_scraps_by_website(self, website: str) -> List[Dict]:
         """Obtener todos los scraps de un sitio web específico"""
@@ -385,6 +400,10 @@ class EnhancedScrapsRegistry:
         except Exception as e:
             self.logger.error(f"Error obteniendo estadísticas: {e}")
             return stats
+
+    def get_registry_stats(self) -> Dict:
+        """Alias de get_statistics para compatibilidad"""
+        return self.get_statistics()
     
     def get_output_path(self, scrap_data: Dict) -> Path:
         """Obtener la ruta de salida para un scrap específico"""

--- a/utils/scraps_registry.py
+++ b/utils/scraps_registry.py
@@ -41,8 +41,8 @@ class ScrapsRegistry:
             2: "renta"
         }
         
-        # Cargar URLs desde el archivo CSV de Lista de URLs
-        self.csv_urls_file = self.project_root / 'Lista de URLs.csv'
+        # Cargar URLs desde el archivo CSV central ubicado en config/
+        self.csv_urls_file = self.project_root / 'config' / 'Lista de URLs.csv'
         self.urls_registry = self.load_urls_from_csv()
         
         # URLs específicas para Inmuebles24 según tu lista (legacy support)


### PR DESCRIPTION
## Summary
- Move `Lista de URLs.csv` into `config/` and include header
- Point registry classes, setup script and tests to new CSV location
- Add helper methods to `EnhancedScrapsRegistry` for compatibility

## Testing
- `pytest test_integration.py::test_csv_structure test_integration.py::test_enhanced_registry -q`


------
https://chatgpt.com/codex/tasks/task_e_68b410b224b883318687732f1ecc0a87