### PR TITLE
Normalize URL CSVs and remove embedded line breaks

### DIFF
--- a/URLs/cyt_urls.csv
+++ b/URLs/cyt_urls.csv
@@ -1,173 +1,172 @@
-# Formato: PaginaWeb,Ciudad,Operación,ProductoPaginaWeb,URL
-PaginaWeb,Ciudad,Operación,ProductoPaginaWeb,URL,ago25_2,sep25_1,sep25_2,oct25_1,oct25_2,nov25_1,nov25_2,dic25_1,dic25_2,ene25_1,ene25_2,feb25_1,feb25_2,mar25_1,mar25_2,abr25_1,abr25_2,may25_1,may25_2,jun25_1,jun25_2,jul25_1,jul25_2,ago25_1,ago25_2,sep25_1,sep25_2
-casas_y_terrenos,El Salto,Rentar,Edificios,https://www.casasyterrenos.com/jalisco/el-salto/edificios/renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,Guadalajara,Rentar,Edificios,https://www.casasyterrenos.com/jalisco/guadalajara/edificios/renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,IxtlahuacÃ¡n de los Membrillos,Rentar,Edificios,https://www.casasyterrenos.com/jalisco/ixtlahuacan-de-los-membrillos/edificios/renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,JuanacatlÃ¡n,Rentar,Edificios,https://www.casasyterrenos.com/jalisco/juanacatlan/edificios/renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,Tlajomulco de ZÃºÃ±iga,Rentar,Edificios,https://www.casasyterrenos.com/jalisco/tlajomulco-de-zuniga/edificios/renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,San Pedro Tlaquepaque,Rentar,Edificios,https://www.casasyterrenos.com/jalisco/tlaquepaque/edificios/renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,TonalÃ¡,Rentar,Edificios,https://www.casasyterrenos.com/jalisco/tonala/edificios/renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,Zapopan,Rentar,Edificios,https://www.casasyterrenos.com/jalisco/zapopan/edificios/renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,Zapotlanejo,Rentar,Edificios,https://www.casasyterrenos.com/jalisco/zapotlanejo/edificios/renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,El Salto,Comprar,Edificios,https://www.casasyterrenos.com/jalisco/el-salto/edificios/venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,Guadalajara,Comprar,Edificios,https://www.casasyterrenos.com/jalisco/guadalajara/edificios/venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,IxtlahuacÃ¡n de los Membrillos,Comprar,Edificios,https://www.casasyterrenos.com/jalisco/ixtlahuacan-de-los-membrillos/edificios/venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,JuanacatlÃ¡n,Comprar,Edificios,https://www.casasyterrenos.com/jalisco/juanacatlan/edificios/venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,Tlajomulco de ZÃºÃ±iga,Comprar,Edificios,https://www.casasyterrenos.com/jalisco/tlajomulco-de-zuniga/edificios/venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,San Pedro Tlaquepaque,Comprar,Edificios,https://www.casasyterrenos.com/jalisco/tlaquepaque/edificios/venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,TonalÃ¡,Comprar,Edificios,https://www.casasyterrenos.com/jalisco/tonala/edificios/venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,Zapopan,Comprar,Edificios,https://www.casasyterrenos.com/jalisco/zapopan/edificios/venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,Zapotlanejo,Comprar,Edificios,https://www.casasyterrenos.com/jalisco/zapotlanejo/edificios/venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,El Salto,Rentar,Terrenos,https://www.casasyterrenos.com/jalisco/el-salto/terrenos/renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,Guadalajara,Rentar,Terrenos,https://www.casasyterrenos.com/jalisco/guadalajara/terrenos/renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,IxtlahuacÃ¡n de los Membrillos,Rentar,Terrenos,https://www.casasyterrenos.com/jalisco/ixtlahuacan-de-los-membrillos/terrenos/renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,JuanacatlÃ¡n,Rentar,Terrenos,https://www.casasyterrenos.com/jalisco/juanacatlan/terrenos/renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,Tlajomulco de ZÃºÃ±iga,Rentar,Terrenos,https://www.casasyterrenos.com/jalisco/tlajomulco-de-zuniga/terrenos/renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,San Pedro Tlaquepaque,Rentar,Terrenos,https://www.casasyterrenos.com/jalisco/tlaquepaque/terrenos/renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,TonalÃ¡,Rentar,Terrenos,https://www.casasyterrenos.com/jalisco/tonala/terrenos/renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,Zapopan,Rentar,Terrenos,https://www.casasyterrenos.com/jalisco/zapopan/terrenos/renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,Zapotlanejo,Rentar,Terrenos,https://www.casasyterrenos.com/jalisco/zapotlanejo/terrenos/renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,El Salto,Comprar,Terrenos,https://www.casasyterrenos.com/jalisco/el-salto/terrenos/venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,Guadalajara,Comprar,Terrenos,https://www.casasyterrenos.com/jalisco/guadalajara/terrenos/venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,IxtlahuacÃ¡n de los Membrillos,Comprar,Terrenos,https://www.casasyterrenos.com/jalisco/ixtlahuacan-de-los-membrillos/terrenos/venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,JuanacatlÃ¡n,Comprar,Terrenos,https://www.casasyterrenos.com/jalisco/juanacatlan/terrenos/venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,Tlajomulco de ZÃºÃ±iga,Comprar,Terrenos,https://www.casasyterrenos.com/jalisco/tlajomulco-de-zuniga/terrenos/venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,San Pedro Tlaquepaque,Comprar,Terrenos,https://www.casasyterrenos.com/jalisco/tlaquepaque/terrenos/venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,TonalÃ¡,Comprar,Terrenos,https://www.casasyterrenos.com/jalisco/tonala/terrenos/venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,Zapopan,Comprar,Terrenos,https://www.casasyterrenos.com/jalisco/zapopan/terrenos/venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,Zapotlanejo,Comprar,Terrenos,https://www.casasyterrenos.com/jalisco/zapotlanejo/terrenos/venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,El Salto,Rentar,Oficinas,https://www.casasyterrenos.com/jalisco/el-salto/oficinas/renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,Guadalajara,Rentar,Oficinas,https://www.casasyterrenos.com/jalisco/guadalajara/oficinas/renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,IxtlahuacÃ¡n de los Membrillos,Rentar,Oficinas,https://www.casasyterrenos.com/jalisco/ixtlahuacan-de-los-membrillos/oficinas/renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,JuanacatlÃ¡n,Rentar,Oficinas,https://www.casasyterrenos.com/jalisco/juanacatlan/oficinas/renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,Tlajomulco de ZÃºÃ±iga,Rentar,Oficinas,https://www.casasyterrenos.com/jalisco/tlajomulco-de-zuniga/oficinas/renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,San Pedro Tlaquepaque,Rentar,Oficinas,https://www.casasyterrenos.com/jalisco/tlaquepaque/oficinas/renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,TonalÃ¡,Rentar,Oficinas,https://www.casasyterrenos.com/jalisco/tonala/oficinas/renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,Zapopan,Rentar,Oficinas,https://www.casasyterrenos.com/jalisco/zapopan/oficinas/renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,Zapotlanejo,Rentar,Oficinas,https://www.casasyterrenos.com/jalisco/zapotlanejo/oficinas/renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,El Salto,Comprar,Oficinas,https://www.casasyterrenos.com/jalisco/el-salto/oficinas/venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,Guadalajara,Comprar,Oficinas,https://www.casasyterrenos.com/jalisco/guadalajara/oficinas/venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,IxtlahuacÃ¡n de los Membrillos,Comprar,Oficinas,https://www.casasyterrenos.com/jalisco/ixtlahuacan-de-los-membrillos/oficinas/venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,JuanacatlÃ¡n,Comprar,Oficinas,https://www.casasyterrenos.com/jalisco/juanacatlan/oficinas/venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,Tlajomulco de ZÃºÃ±iga,Comprar,Oficinas,https://www.casasyterrenos.com/jalisco/tlajomulco-de-zuniga/oficinas/venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,San Pedro Tlaquepaque,Comprar,Oficinas,https://www.casasyterrenos.com/jalisco/tlaquepaque/oficinas/venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,TonalÃ¡,Comprar,Oficinas,https://www.casasyterrenos.com/jalisco/tonala/oficinas/venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,Zapopan,Comprar,Oficinas,https://www.casasyterrenos.com/jalisco/zapopan/oficinas/venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,Zapotlanejo,Comprar,Oficinas,https://www.casasyterrenos.com/jalisco/zapotlanejo/oficinas/venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,El Salto,Rentar,Ranchos,https://www.casasyterrenos.com/jalisco/el-salto/ranchos/renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,Guadalajara,Rentar,Ranchos,https://www.casasyterrenos.com/jalisco/guadalajara/ranchos/renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,IxtlahuacÃ¡n de los Membrillos,Rentar,Ranchos,https://www.casasyterrenos.com/jalisco/ixtlahuacan-de-los-membrillos/ranchos/renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,JuanacatlÃ¡n,Rentar,Ranchos,https://www.casasyterrenos.com/jalisco/juanacatlan/ranchos/renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,Tlajomulco de ZÃºÃ±iga,Rentar,Ranchos,https://www.casasyterrenos.com/jalisco/tlajomulco-de-zuniga/ranchos/renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,San Pedro Tlaquepaque,Rentar,Ranchos,https://www.casasyterrenos.com/jalisco/tlaquepaque/ranchos/renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,TonalÃ¡,Rentar,Ranchos,https://www.casasyterrenos.com/jalisco/tonala/ranchos/renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,Zapopan,Rentar,Ranchos,https://www.casasyterrenos.com/jalisco/zapopan/ranchos/renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,Zapotlanejo,Rentar,Ranchos,https://www.casasyterrenos.com/jalisco/zapotlanejo/ranchos/renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,El Salto,Comprar,Ranchos,https://www.casasyterrenos.com/jalisco/el-salto/ranchos/venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,Guadalajara,Comprar,Ranchos,https://www.casasyterrenos.com/jalisco/guadalajara/ranchos/venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,IxtlahuacÃ¡n de los Membrillos,Comprar,Ranchos,https://www.casasyterrenos.com/jalisco/ixtlahuacan-de-los-membrillos/ranchos/venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,JuanacatlÃ¡n,Comprar,Ranchos,https://www.casasyterrenos.com/jalisco/juanacatlan/ranchos/venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,Tlajomulco de ZÃºÃ±iga,Comprar,Ranchos,https://www.casasyterrenos.com/jalisco/tlajomulco-de-zuniga/ranchos/venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,San Pedro Tlaquepaque,Comprar,Ranchos,https://www.casasyterrenos.com/jalisco/tlaquepaque/ranchos/venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,TonalÃ¡,Comprar,Ranchos,https://www.casasyterrenos.com/jalisco/tonala/ranchos/venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,Zapopan,Comprar,Ranchos,https://www.casasyterrenos.com/jalisco/zapopan/ranchos/venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,Zapotlanejo,Comprar,Ranchos,https://www.casasyterrenos.com/jalisco/zapotlanejo/ranchos/venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,El Salto,Rentar,Locales,https://www.casasyterrenos.com/jalisco/el-salto/locales/renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,Guadalajara,Rentar,Locales,https://www.casasyterrenos.com/jalisco/guadalajara/locales/renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,IxtlahuacÃ¡n de los Membrillos,Rentar,Locales,https://www.casasyterrenos.com/jalisco/ixtlahuacan-de-los-membrillos/locales/renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,JuanacatlÃ¡n,Rentar,Locales,https://www.casasyterrenos.com/jalisco/juanacatlan/locales/renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,Tlajomulco de ZÃºÃ±iga,Rentar,Locales,https://www.casasyterrenos.com/jalisco/tlajomulco-de-zuniga/locales/renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,San Pedro Tlaquepaque,Rentar,Locales,https://www.casasyterrenos.com/jalisco/tlaquepaque/locales/renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,TonalÃ¡,Rentar,Locales,https://www.casasyterrenos.com/jalisco/tonala/locales/renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,Zapopan,Rentar,Locales,https://www.casasyterrenos.com/jalisco/zapopan/locales/renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,Zapotlanejo,Rentar,Locales,https://www.casasyterrenos.com/jalisco/zapotlanejo/locales/renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,El Salto,Comprar,Locales,https://www.casasyterrenos.com/jalisco/el-salto/locales/venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,Guadalajara,Comprar,Locales,https://www.casasyterrenos.com/jalisco/guadalajara/locales/venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,IxtlahuacÃ¡n de los Membrillos,Comprar,Locales,https://www.casasyterrenos.com/jalisco/ixtlahuacan-de-los-membrillos/locales/venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,JuanacatlÃ¡n,Comprar,Locales,https://www.casasyterrenos.com/jalisco/juanacatlan/locales/venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,Tlajomulco de ZÃºÃ±iga,Comprar,Locales,https://www.casasyterrenos.com/jalisco/tlajomulco-de-zuniga/locales/venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,San Pedro Tlaquepaque,Comprar,Locales,https://www.casasyterrenos.com/jalisco/tlaquepaque/locales/venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,TonalÃ¡,Comprar,Locales,https://www.casasyterrenos.com/jalisco/tonala/locales/venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,Zapopan,Comprar,Locales,https://www.casasyterrenos.com/jalisco/zapopan/locales/venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,Zapotlanejo,Comprar,Locales,https://www.casasyterrenos.com/jalisco/zapotlanejo/locales/venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,El Salto,Desarrollos,Desarrollos,https://www.casasyterrenos.com/desarrollos/jalisco/el-salto,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,Guadalajara,Desarrollos,Desarrollos,https://www.casasyterrenos.com/desarrollos/jalisco/guadalajara,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,IxtlahuacÃ¡n de los Membrillos,Desarrollos,Desarrollos,https://www.casasyterrenos.com/desarrollos/jalisco/ixtlahuacan-de-los-membrillos,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,JuanacatlÃ¡n,Desarrollos,Desarrollos,https://www.casasyterrenos.com/desarrollos/jalisco/juanacatlan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,Tlajomulco de ZÃºÃ±iga,Desarrollos,Desarrollos,https://www.casasyterrenos.com/desarrollos/jalisco/tlajomulco-de-zuniga,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,San Pedro Tlaquepaque,Desarrollos,Desarrollos,https://www.casasyterrenos.com/desarrollos/jalisco/tlaquepaque,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,TonalÃ¡,Desarrollos,Desarrollos,https://www.casasyterrenos.com/desarrollos/jalisco/tonala,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,Zapopan,Desarrollos,Desarrollos,https://www.casasyterrenos.com/desarrollos/jalisco/zapopan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,Zapotlanejo,Desarrollos,Desarrollos,https://www.casasyterrenos.com/desarrollos/jalisco/zapotlanejo,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,El Salto,Rentar,Departamentos,https://www.casasyterrenos.com/jalisco/el-salto/departamentos/renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,Guadalajara,Rentar,Departamentos,https://www.casasyterrenos.com/jalisco/guadalajara/departamentos/renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,IxtlahuacÃ¡n de los Membrillos,Rentar,Departamentos,https://www.casasyterrenos.com/jalisco/ixtlahuacan-de-los-membrillos/departamentos/renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,JuanacatlÃ¡n,Rentar,Departamentos,https://www.casasyterrenos.com/jalisco/juanacatlan/departamentos/renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,Tlajomulco de ZÃºÃ±iga,Rentar,Departamentos,https://www.casasyterrenos.com/jalisco/tlajomulco-de-zuniga/departamentos/renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,San Pedro Tlaquepaque,Rentar,Departamentos,https://www.casasyterrenos.com/jalisco/tlaquepaque/departamentos/renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,TonalÃ¡,Rentar,Departamentos,https://www.casasyterrenos.com/jalisco/tonala/departamentos/renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,Zapopan,Rentar,Departamentos,https://www.casasyterrenos.com/jalisco/zapopan/departamentos/renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,Zapotlanejo,Rentar,Departamentos,https://www.casasyterrenos.com/jalisco/zapotlanejo/departamentos/renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,El Salto,Comprar,Departamentos,https://www.casasyterrenos.com/jalisco/el-salto/departamentos/venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,Guadalajara,Comprar,Departamentos,https://www.casasyterrenos.com/jalisco/guadalajara/departamentos/venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,IxtlahuacÃ¡n de los Membrillos,Comprar,Departamentos,https://www.casasyterrenos.com/jalisco/ixtlahuacan-de-los-membrillos/departamentos/venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,JuanacatlÃ¡n,Comprar,Departamentos,https://www.casasyterrenos.com/jalisco/juanacatlan/departamentos/venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,Tlajomulco de ZÃºÃ±iga,Comprar,Departamentos,https://www.casasyterrenos.com/jalisco/tlajomulco-de-zuniga/departamentos/venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,San Pedro Tlaquepaque,Comprar,Departamentos,https://www.casasyterrenos.com/jalisco/tlaquepaque/departamentos/venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,TonalÃ¡,Comprar,Departamentos,https://www.casasyterrenos.com/jalisco/tonala/departamentos/venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,Zapopan,Comprar,Departamentos,https://www.casasyterrenos.com/jalisco/zapopan/departamentos/venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,Zapotlanejo,Comprar,Departamentos,https://www.casasyterrenos.com/jalisco/zapotlanejo/departamentos/venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,El Salto,Rentar,Consultorios,https://www.casasyterrenos.com/jalisco/el-salto/consultorios/renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,Guadalajara,Rentar,Consultorios,https://www.casasyterrenos.com/jalisco/guadalajara/consultorios/renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,IxtlahuacÃ¡n de los Membrillos,Rentar,Consultorios,https://www.casasyterrenos.com/jalisco/ixtlahuacan-de-los-membrillos/consultorios/renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,JuanacatlÃ¡n,Rentar,Consultorios,https://www.casasyterrenos.com/jalisco/juanacatlan/consultorios/renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,Tlajomulco de ZÃºÃ±iga,Rentar,Consultorios,https://www.casasyterrenos.com/jalisco/tlajomulco-de-zuniga/consultorios/renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,San Pedro Tlaquepaque,Rentar,Consultorios,https://www.casasyterrenos.com/jalisco/tlaquepaque/consultorios/renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,TonalÃ¡,Rentar,Consultorios,https://www.casasyterrenos.com/jalisco/tonala/consultorios/renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,Zapopan,Rentar,Consultorios,https://www.casasyterrenos.com/jalisco/zapopan/consultorios/renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,Zapotlanejo,Rentar,Consultorios,https://www.casasyterrenos.com/jalisco/zapotlanejo/consultorios/renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,El Salto,Comprar,Consultorios,https://www.casasyterrenos.com/jalisco/el-salto/consultorios/venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,Guadalajara,Comprar,Consultorios,https://www.casasyterrenos.com/jalisco/guadalajara/consultorios/venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,IxtlahuacÃ¡n de los Membrillos,Comprar,Consultorios,https://www.casasyterrenos.com/jalisco/ixtlahuacan-de-los-membrillos/consultorios/venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,JuanacatlÃ¡n,Comprar,Consultorios,https://www.casasyterrenos.com/jalisco/juanacatlan/consultorios/venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,Tlajomulco de ZÃºÃ±iga,Comprar,Consultorios,https://www.casasyterrenos.com/jalisco/tlajomulco-de-zuniga/consultorios/venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,San Pedro Tlaquepaque,Comprar,Consultorios,https://www.casasyterrenos.com/jalisco/tlaquepaque/consultorios/venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,TonalÃ¡,Comprar,Consultorios,https://www.casasyterrenos.com/jalisco/tonala/consultorios/venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,Zapopan,Comprar,Consultorios,https://www.casasyterrenos.com/jalisco/zapopan/consultorios/venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,Zapotlanejo,Comprar,Consultorios,https://www.casasyterrenos.com/jalisco/zapotlanejo/consultorios/venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,El Salto,Rentar,Casas,https://www.casasyterrenos.com/jalisco/el-salto/casas/renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,Guadalajara,Rentar,Casas,https://www.casasyterrenos.com/jalisco/guadalajara/casas/renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,IxtlahuacÃ¡n de los Membrillos,Rentar,Casas,https://www.casasyterrenos.com/jalisco/ixtlahuacan-de-los-membrillos/casas/renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,JuanacatlÃ¡n,Rentar,Casas,https://www.casasyterrenos.com/jalisco/juanacatlan/casas/renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,Tlajomulco de ZÃºÃ±iga,Rentar,Casas,https://www.casasyterrenos.com/jalisco/tlajomulco-de-zuniga/casas/renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,San Pedro Tlaquepaque,Rentar,Casas,https://www.casasyterrenos.com/jalisco/tlaquepaque/casas/renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,TonalÃ¡,Rentar,Casas,https://www.casasyterrenos.com/jalisco/tonala/casas/renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,Zapopan,Rentar,Casas,https://www.casasyterrenos.com/jalisco/zapopan/casas/renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,Zapotlanejo,Rentar,Casas,https://www.casasyterrenos.com/jalisco/zapotlanejo/casas/renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,El Salto,Comprar,Casas,https://www.casasyterrenos.com/jalisco/el-salto/casas/venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,Guadalajara,Comprar,Casas,https://www.casasyterrenos.com/jalisco/guadalajara/casas/venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,IxtlahuacÃ¡n de los Membrillos,Comprar,Casas,https://www.casasyterrenos.com/jalisco/ixtlahuacan-de-los-membrillos/casas/venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,JuanacatlÃ¡n,Comprar,Casas,https://www.casasyterrenos.com/jalisco/juanacatlan/casas/venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,Tlajomulco de ZÃºÃ±iga,Comprar,Casas,https://www.casasyterrenos.com/jalisco/tlajomulco-de-zuniga/casas/venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,San Pedro Tlaquepaque,Comprar,Casas,https://www.casasyterrenos.com/jalisco/tlaquepaque/casas/venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,TonalÃ¡,Comprar,Casas,https://www.casasyterrenos.com/jalisco/tonala/casas/venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,Zapopan,Comprar,Casas,https://www.casasyterrenos.com/jalisco/zapopan/casas/venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,Zapotlanejo,Comprar,Casas,https://www.casasyterrenos.com/jalisco/zapotlanejo/casas/venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,El Salto,Rentar,Bodegas,https://www.casasyterrenos.com/jalisco/el-salto/bodegas/renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,Guadalajara,Rentar,Bodegas,https://www.casasyterrenos.com/jalisco/guadalajara/bodegas/renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,IxtlahuacÃ¡n de los Membrillos,Rentar,Bodegas,https://www.casasyterrenos.com/jalisco/ixtlahuacan-de-los-membrillos/bodegas/renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,JuanacatlÃ¡n,Rentar,Bodegas,https://www.casasyterrenos.com/jalisco/juanacatlan/bodegas/renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,Tlajomulco de ZÃºÃ±iga,Rentar,Bodegas,https://www.casasyterrenos.com/jalisco/tlajomulco-de-zuniga/bodegas/renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,San Pedro Tlaquepaque,Rentar,Bodegas,https://www.casasyterrenos.com/jalisco/tlaquepaque/bodegas/renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,TonalÃ¡,Rentar,Bodegas,https://www.casasyterrenos.com/jalisco/tonala/bodegas/renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,Zapopan,Rentar,Bodegas,https://www.casasyterrenos.com/jalisco/zapopan/bodegas/renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,Zapotlanejo,Rentar,Bodegas,https://www.casasyterrenos.com/jalisco/zapotlanejo/bodegas/renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,El Salto,Comprar,Bodegas,https://www.casasyterrenos.com/jalisco/el-salto/bodegas/venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,Guadalajara,Comprar,Bodegas,https://www.casasyterrenos.com/jalisco/guadalajara/bodegas/venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,IxtlahuacÃ¡n de los Membrillos,Comprar,Bodegas,https://www.casasyterrenos.com/jalisco/ixtlahuacan-de-los-membrillos/bodegas/venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,JuanacatlÃ¡n,Comprar,Bodegas,https://www.casasyterrenos.com/jalisco/juanacatlan/bodegas/venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,Tlajomulco de ZÃºÃ±iga,Comprar,Bodegas,https://www.casasyterrenos.com/jalisco/tlajomulco-de-zuniga/bodegas/venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,San Pedro Tlaquepaque,Comprar,Bodegas,https://www.casasyterrenos.com/jalisco/tlaquepaque/bodegas/venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,TonalÃ¡,Comprar,Bodegas,https://www.casasyterrenos.com/jalisco/tonala/bodegas/venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,Zapopan,Comprar,Bodegas,https://www.casasyterrenos.com/jalisco/zapopan/bodegas/venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-casas_y_terrenos,Zapotlanejo,Comprar,Bodegas,https://www.casasyterrenos.com/jalisco/zapotlanejo/bodegas/venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
+PaginaWeb,Ciudad,Operación,ProductoPaginaWeb,URL
+casas_y_terrenos,El Salto,Rentar,Edificios,https://www.casasyterrenos.com/jalisco/el-salto/edificios/renta
+casas_y_terrenos,Guadalajara,Rentar,Edificios,https://www.casasyterrenos.com/jalisco/guadalajara/edificios/renta
+casas_y_terrenos,Ixtlahuacán de los Membrillos,Rentar,Edificios,https://www.casasyterrenos.com/jalisco/ixtlahuacan-de-los-membrillos/edificios/renta
+casas_y_terrenos,Juanacatlán,Rentar,Edificios,https://www.casasyterrenos.com/jalisco/juanacatlan/edificios/renta
+casas_y_terrenos,Tlajomulco de Zúñiga,Rentar,Edificios,https://www.casasyterrenos.com/jalisco/tlajomulco-de-zuniga/edificios/renta
+casas_y_terrenos,San Pedro Tlaquepaque,Rentar,Edificios,https://www.casasyterrenos.com/jalisco/tlaquepaque/edificios/renta
+casas_y_terrenos,Tonalá,Rentar,Edificios,https://www.casasyterrenos.com/jalisco/tonala/edificios/renta
+casas_y_terrenos,Zapopan,Rentar,Edificios,https://www.casasyterrenos.com/jalisco/zapopan/edificios/renta
+casas_y_terrenos,Zapotlanejo,Rentar,Edificios,https://www.casasyterrenos.com/jalisco/zapotlanejo/edificios/renta
+casas_y_terrenos,El Salto,Comprar,Edificios,https://www.casasyterrenos.com/jalisco/el-salto/edificios/venta
+casas_y_terrenos,Guadalajara,Comprar,Edificios,https://www.casasyterrenos.com/jalisco/guadalajara/edificios/venta
+casas_y_terrenos,Ixtlahuacán de los Membrillos,Comprar,Edificios,https://www.casasyterrenos.com/jalisco/ixtlahuacan-de-los-membrillos/edificios/venta
+casas_y_terrenos,Juanacatlán,Comprar,Edificios,https://www.casasyterrenos.com/jalisco/juanacatlan/edificios/venta
+casas_y_terrenos,Tlajomulco de Zúñiga,Comprar,Edificios,https://www.casasyterrenos.com/jalisco/tlajomulco-de-zuniga/edificios/venta
+casas_y_terrenos,San Pedro Tlaquepaque,Comprar,Edificios,https://www.casasyterrenos.com/jalisco/tlaquepaque/edificios/venta
+casas_y_terrenos,Tonalá,Comprar,Edificios,https://www.casasyterrenos.com/jalisco/tonala/edificios/venta
+casas_y_terrenos,Zapopan,Comprar,Edificios,https://www.casasyterrenos.com/jalisco/zapopan/edificios/venta
+casas_y_terrenos,Zapotlanejo,Comprar,Edificios,https://www.casasyterrenos.com/jalisco/zapotlanejo/edificios/venta
+casas_y_terrenos,El Salto,Rentar,Terrenos,https://www.casasyterrenos.com/jalisco/el-salto/terrenos/renta
+casas_y_terrenos,Guadalajara,Rentar,Terrenos,https://www.casasyterrenos.com/jalisco/guadalajara/terrenos/renta
+casas_y_terrenos,Ixtlahuacán de los Membrillos,Rentar,Terrenos,https://www.casasyterrenos.com/jalisco/ixtlahuacan-de-los-membrillos/terrenos/renta
+casas_y_terrenos,Juanacatlán,Rentar,Terrenos,https://www.casasyterrenos.com/jalisco/juanacatlan/terrenos/renta
+casas_y_terrenos,Tlajomulco de Zúñiga,Rentar,Terrenos,https://www.casasyterrenos.com/jalisco/tlajomulco-de-zuniga/terrenos/renta
+casas_y_terrenos,San Pedro Tlaquepaque,Rentar,Terrenos,https://www.casasyterrenos.com/jalisco/tlaquepaque/terrenos/renta
+casas_y_terrenos,Tonalá,Rentar,Terrenos,https://www.casasyterrenos.com/jalisco/tonala/terrenos/renta
+casas_y_terrenos,Zapopan,Rentar,Terrenos,https://www.casasyterrenos.com/jalisco/zapopan/terrenos/renta
+casas_y_terrenos,Zapotlanejo,Rentar,Terrenos,https://www.casasyterrenos.com/jalisco/zapotlanejo/terrenos/renta
+casas_y_terrenos,El Salto,Comprar,Terrenos,https://www.casasyterrenos.com/jalisco/el-salto/terrenos/venta
+casas_y_terrenos,Guadalajara,Comprar,Terrenos,https://www.casasyterrenos.com/jalisco/guadalajara/terrenos/venta
+casas_y_terrenos,Ixtlahuacán de los Membrillos,Comprar,Terrenos,https://www.casasyterrenos.com/jalisco/ixtlahuacan-de-los-membrillos/terrenos/venta
+casas_y_terrenos,Juanacatlán,Comprar,Terrenos,https://www.casasyterrenos.com/jalisco/juanacatlan/terrenos/venta
+casas_y_terrenos,Tlajomulco de Zúñiga,Comprar,Terrenos,https://www.casasyterrenos.com/jalisco/tlajomulco-de-zuniga/terrenos/venta
+casas_y_terrenos,San Pedro Tlaquepaque,Comprar,Terrenos,https://www.casasyterrenos.com/jalisco/tlaquepaque/terrenos/venta
+casas_y_terrenos,Tonalá,Comprar,Terrenos,https://www.casasyterrenos.com/jalisco/tonala/terrenos/venta
+casas_y_terrenos,Zapopan,Comprar,Terrenos,https://www.casasyterrenos.com/jalisco/zapopan/terrenos/venta
+casas_y_terrenos,Zapotlanejo,Comprar,Terrenos,https://www.casasyterrenos.com/jalisco/zapotlanejo/terrenos/venta
+casas_y_terrenos,El Salto,Rentar,Oficinas,https://www.casasyterrenos.com/jalisco/el-salto/oficinas/renta
+casas_y_terrenos,Guadalajara,Rentar,Oficinas,https://www.casasyterrenos.com/jalisco/guadalajara/oficinas/renta
+casas_y_terrenos,Ixtlahuacán de los Membrillos,Rentar,Oficinas,https://www.casasyterrenos.com/jalisco/ixtlahuacan-de-los-membrillos/oficinas/renta
+casas_y_terrenos,Juanacatlán,Rentar,Oficinas,https://www.casasyterrenos.com/jalisco/juanacatlan/oficinas/renta
+casas_y_terrenos,Tlajomulco de Zúñiga,Rentar,Oficinas,https://www.casasyterrenos.com/jalisco/tlajomulco-de-zuniga/oficinas/renta
+casas_y_terrenos,San Pedro Tlaquepaque,Rentar,Oficinas,https://www.casasyterrenos.com/jalisco/tlaquepaque/oficinas/renta
+casas_y_terrenos,Tonalá,Rentar,Oficinas,https://www.casasyterrenos.com/jalisco/tonala/oficinas/renta
+casas_y_terrenos,Zapopan,Rentar,Oficinas,https://www.casasyterrenos.com/jalisco/zapopan/oficinas/renta
+casas_y_terrenos,Zapotlanejo,Rentar,Oficinas,https://www.casasyterrenos.com/jalisco/zapotlanejo/oficinas/renta
+casas_y_terrenos,El Salto,Comprar,Oficinas,https://www.casasyterrenos.com/jalisco/el-salto/oficinas/venta
+casas_y_terrenos,Guadalajara,Comprar,Oficinas,https://www.casasyterrenos.com/jalisco/guadalajara/oficinas/venta
+casas_y_terrenos,Ixtlahuacán de los Membrillos,Comprar,Oficinas,https://www.casasyterrenos.com/jalisco/ixtlahuacan-de-los-membrillos/oficinas/venta
+casas_y_terrenos,Juanacatlán,Comprar,Oficinas,https://www.casasyterrenos.com/jalisco/juanacatlan/oficinas/venta
+casas_y_terrenos,Tlajomulco de Zúñiga,Comprar,Oficinas,https://www.casasyterrenos.com/jalisco/tlajomulco-de-zuniga/oficinas/venta
+casas_y_terrenos,San Pedro Tlaquepaque,Comprar,Oficinas,https://www.casasyterrenos.com/jalisco/tlaquepaque/oficinas/venta
+casas_y_terrenos,Tonalá,Comprar,Oficinas,https://www.casasyterrenos.com/jalisco/tonala/oficinas/venta
+casas_y_terrenos,Zapopan,Comprar,Oficinas,https://www.casasyterrenos.com/jalisco/zapopan/oficinas/venta
+casas_y_terrenos,Zapotlanejo,Comprar,Oficinas,https://www.casasyterrenos.com/jalisco/zapotlanejo/oficinas/venta
+casas_y_terrenos,El Salto,Rentar,Ranchos,https://www.casasyterrenos.com/jalisco/el-salto/ranchos/renta
+casas_y_terrenos,Guadalajara,Rentar,Ranchos,https://www.casasyterrenos.com/jalisco/guadalajara/ranchos/renta
+casas_y_terrenos,Ixtlahuacán de los Membrillos,Rentar,Ranchos,https://www.casasyterrenos.com/jalisco/ixtlahuacan-de-los-membrillos/ranchos/renta
+casas_y_terrenos,Juanacatlán,Rentar,Ranchos,https://www.casasyterrenos.com/jalisco/juanacatlan/ranchos/renta
+casas_y_terrenos,Tlajomulco de Zúñiga,Rentar,Ranchos,https://www.casasyterrenos.com/jalisco/tlajomulco-de-zuniga/ranchos/renta
+casas_y_terrenos,San Pedro Tlaquepaque,Rentar,Ranchos,https://www.casasyterrenos.com/jalisco/tlaquepaque/ranchos/renta
+casas_y_terrenos,Tonalá,Rentar,Ranchos,https://www.casasyterrenos.com/jalisco/tonala/ranchos/renta
+casas_y_terrenos,Zapopan,Rentar,Ranchos,https://www.casasyterrenos.com/jalisco/zapopan/ranchos/renta
+casas_y_terrenos,Zapotlanejo,Rentar,Ranchos,https://www.casasyterrenos.com/jalisco/zapotlanejo/ranchos/renta
+casas_y_terrenos,El Salto,Comprar,Ranchos,https://www.casasyterrenos.com/jalisco/el-salto/ranchos/venta
+casas_y_terrenos,Guadalajara,Comprar,Ranchos,https://www.casasyterrenos.com/jalisco/guadalajara/ranchos/venta
+casas_y_terrenos,Ixtlahuacán de los Membrillos,Comprar,Ranchos,https://www.casasyterrenos.com/jalisco/ixtlahuacan-de-los-membrillos/ranchos/venta
+casas_y_terrenos,Juanacatlán,Comprar,Ranchos,https://www.casasyterrenos.com/jalisco/juanacatlan/ranchos/venta
+casas_y_terrenos,Tlajomulco de Zúñiga,Comprar,Ranchos,https://www.casasyterrenos.com/jalisco/tlajomulco-de-zuniga/ranchos/venta
+casas_y_terrenos,San Pedro Tlaquepaque,Comprar,Ranchos,https://www.casasyterrenos.com/jalisco/tlaquepaque/ranchos/venta
+casas_y_terrenos,Tonalá,Comprar,Ranchos,https://www.casasyterrenos.com/jalisco/tonala/ranchos/venta
+casas_y_terrenos,Zapopan,Comprar,Ranchos,https://www.casasyterrenos.com/jalisco/zapopan/ranchos/venta
+casas_y_terrenos,Zapotlanejo,Comprar,Ranchos,https://www.casasyterrenos.com/jalisco/zapotlanejo/ranchos/venta
+casas_y_terrenos,El Salto,Rentar,Locales,https://www.casasyterrenos.com/jalisco/el-salto/locales/renta
+casas_y_terrenos,Guadalajara,Rentar,Locales,https://www.casasyterrenos.com/jalisco/guadalajara/locales/renta
+casas_y_terrenos,Ixtlahuacán de los Membrillos,Rentar,Locales,https://www.casasyterrenos.com/jalisco/ixtlahuacan-de-los-membrillos/locales/renta
+casas_y_terrenos,Juanacatlán,Rentar,Locales,https://www.casasyterrenos.com/jalisco/juanacatlan/locales/renta
+casas_y_terrenos,Tlajomulco de Zúñiga,Rentar,Locales,https://www.casasyterrenos.com/jalisco/tlajomulco-de-zuniga/locales/renta
+casas_y_terrenos,San Pedro Tlaquepaque,Rentar,Locales,https://www.casasyterrenos.com/jalisco/tlaquepaque/locales/renta
+casas_y_terrenos,Tonalá,Rentar,Locales,https://www.casasyterrenos.com/jalisco/tonala/locales/renta
+casas_y_terrenos,Zapopan,Rentar,Locales,https://www.casasyterrenos.com/jalisco/zapopan/locales/renta
+casas_y_terrenos,Zapotlanejo,Rentar,Locales,https://www.casasyterrenos.com/jalisco/zapotlanejo/locales/renta
+casas_y_terrenos,El Salto,Comprar,Locales,https://www.casasyterrenos.com/jalisco/el-salto/locales/venta
+casas_y_terrenos,Guadalajara,Comprar,Locales,https://www.casasyterrenos.com/jalisco/guadalajara/locales/venta
+casas_y_terrenos,Ixtlahuacán de los Membrillos,Comprar,Locales,https://www.casasyterrenos.com/jalisco/ixtlahuacan-de-los-membrillos/locales/venta
+casas_y_terrenos,Juanacatlán,Comprar,Locales,https://www.casasyterrenos.com/jalisco/juanacatlan/locales/venta
+casas_y_terrenos,Tlajomulco de Zúñiga,Comprar,Locales,https://www.casasyterrenos.com/jalisco/tlajomulco-de-zuniga/locales/venta
+casas_y_terrenos,San Pedro Tlaquepaque,Comprar,Locales,https://www.casasyterrenos.com/jalisco/tlaquepaque/locales/venta
+casas_y_terrenos,Tonalá,Comprar,Locales,https://www.casasyterrenos.com/jalisco/tonala/locales/venta
+casas_y_terrenos,Zapopan,Comprar,Locales,https://www.casasyterrenos.com/jalisco/zapopan/locales/venta
+casas_y_terrenos,Zapotlanejo,Comprar,Locales,https://www.casasyterrenos.com/jalisco/zapotlanejo/locales/venta
+casas_y_terrenos,El Salto,Desarrollos,Desarrollos,https://www.casasyterrenos.com/desarrollos/jalisco/el-salto
+casas_y_terrenos,Guadalajara,Desarrollos,Desarrollos,https://www.casasyterrenos.com/desarrollos/jalisco/guadalajara
+casas_y_terrenos,Ixtlahuacán de los Membrillos,Desarrollos,Desarrollos,https://www.casasyterrenos.com/desarrollos/jalisco/ixtlahuacan-de-los-membrillos
+casas_y_terrenos,Juanacatlán,Desarrollos,Desarrollos,https://www.casasyterrenos.com/desarrollos/jalisco/juanacatlan
+casas_y_terrenos,Tlajomulco de Zúñiga,Desarrollos,Desarrollos,https://www.casasyterrenos.com/desarrollos/jalisco/tlajomulco-de-zuniga
+casas_y_terrenos,San Pedro Tlaquepaque,Desarrollos,Desarrollos,https://www.casasyterrenos.com/desarrollos/jalisco/tlaquepaque
+casas_y_terrenos,Tonalá,Desarrollos,Desarrollos,https://www.casasyterrenos.com/desarrollos/jalisco/tonala
+casas_y_terrenos,Zapopan,Desarrollos,Desarrollos,https://www.casasyterrenos.com/desarrollos/jalisco/zapopan
+casas_y_terrenos,Zapotlanejo,Desarrollos,Desarrollos,https://www.casasyterrenos.com/desarrollos/jalisco/zapotlanejo
+casas_y_terrenos,El Salto,Rentar,Departamentos,https://www.casasyterrenos.com/jalisco/el-salto/departamentos/renta
+casas_y_terrenos,Guadalajara,Rentar,Departamentos,https://www.casasyterrenos.com/jalisco/guadalajara/departamentos/renta
+casas_y_terrenos,Ixtlahuacán de los Membrillos,Rentar,Departamentos,https://www.casasyterrenos.com/jalisco/ixtlahuacan-de-los-membrillos/departamentos/renta
+casas_y_terrenos,Juanacatlán,Rentar,Departamentos,https://www.casasyterrenos.com/jalisco/juanacatlan/departamentos/renta
+casas_y_terrenos,Tlajomulco de Zúñiga,Rentar,Departamentos,https://www.casasyterrenos.com/jalisco/tlajomulco-de-zuniga/departamentos/renta
+casas_y_terrenos,San Pedro Tlaquepaque,Rentar,Departamentos,https://www.casasyterrenos.com/jalisco/tlaquepaque/departamentos/renta
+casas_y_terrenos,Tonalá,Rentar,Departamentos,https://www.casasyterrenos.com/jalisco/tonala/departamentos/renta
+casas_y_terrenos,Zapopan,Rentar,Departamentos,https://www.casasyterrenos.com/jalisco/zapopan/departamentos/renta
+casas_y_terrenos,Zapotlanejo,Rentar,Departamentos,https://www.casasyterrenos.com/jalisco/zapotlanejo/departamentos/renta
+casas_y_terrenos,El Salto,Comprar,Departamentos,https://www.casasyterrenos.com/jalisco/el-salto/departamentos/venta
+casas_y_terrenos,Guadalajara,Comprar,Departamentos,https://www.casasyterrenos.com/jalisco/guadalajara/departamentos/venta
+casas_y_terrenos,Ixtlahuacán de los Membrillos,Comprar,Departamentos,https://www.casasyterrenos.com/jalisco/ixtlahuacan-de-los-membrillos/departamentos/venta
+casas_y_terrenos,Juanacatlán,Comprar,Departamentos,https://www.casasyterrenos.com/jalisco/juanacatlan/departamentos/venta
+casas_y_terrenos,Tlajomulco de Zúñiga,Comprar,Departamentos,https://www.casasyterrenos.com/jalisco/tlajomulco-de-zuniga/departamentos/venta
+casas_y_terrenos,San Pedro Tlaquepaque,Comprar,Departamentos,https://www.casasyterrenos.com/jalisco/tlaquepaque/departamentos/venta
+casas_y_terrenos,Tonalá,Comprar,Departamentos,https://www.casasyterrenos.com/jalisco/tonala/departamentos/venta
+casas_y_terrenos,Zapopan,Comprar,Departamentos,https://www.casasyterrenos.com/jalisco/zapopan/departamentos/venta
+casas_y_terrenos,Zapotlanejo,Comprar,Departamentos,https://www.casasyterrenos.com/jalisco/zapotlanejo/departamentos/venta
+casas_y_terrenos,El Salto,Rentar,Consultorios,https://www.casasyterrenos.com/jalisco/el-salto/consultorios/renta
+casas_y_terrenos,Guadalajara,Rentar,Consultorios,https://www.casasyterrenos.com/jalisco/guadalajara/consultorios/renta
+casas_y_terrenos,Ixtlahuacán de los Membrillos,Rentar,Consultorios,https://www.casasyterrenos.com/jalisco/ixtlahuacan-de-los-membrillos/consultorios/renta
+casas_y_terrenos,Juanacatlán,Rentar,Consultorios,https://www.casasyterrenos.com/jalisco/juanacatlan/consultorios/renta
+casas_y_terrenos,Tlajomulco de Zúñiga,Rentar,Consultorios,https://www.casasyterrenos.com/jalisco/tlajomulco-de-zuniga/consultorios/renta
+casas_y_terrenos,San Pedro Tlaquepaque,Rentar,Consultorios,https://www.casasyterrenos.com/jalisco/tlaquepaque/consultorios/renta
+casas_y_terrenos,Tonalá,Rentar,Consultorios,https://www.casasyterrenos.com/jalisco/tonala/consultorios/renta
+casas_y_terrenos,Zapopan,Rentar,Consultorios,https://www.casasyterrenos.com/jalisco/zapopan/consultorios/renta
+casas_y_terrenos,Zapotlanejo,Rentar,Consultorios,https://www.casasyterrenos.com/jalisco/zapotlanejo/consultorios/renta
+casas_y_terrenos,El Salto,Comprar,Consultorios,https://www.casasyterrenos.com/jalisco/el-salto/consultorios/venta
+casas_y_terrenos,Guadalajara,Comprar,Consultorios,https://www.casasyterrenos.com/jalisco/guadalajara/consultorios/venta
+casas_y_terrenos,Ixtlahuacán de los Membrillos,Comprar,Consultorios,https://www.casasyterrenos.com/jalisco/ixtlahuacan-de-los-membrillos/consultorios/venta
+casas_y_terrenos,Juanacatlán,Comprar,Consultorios,https://www.casasyterrenos.com/jalisco/juanacatlan/consultorios/venta
+casas_y_terrenos,Tlajomulco de Zúñiga,Comprar,Consultorios,https://www.casasyterrenos.com/jalisco/tlajomulco-de-zuniga/consultorios/venta
+casas_y_terrenos,San Pedro Tlaquepaque,Comprar,Consultorios,https://www.casasyterrenos.com/jalisco/tlaquepaque/consultorios/venta
+casas_y_terrenos,Tonalá,Comprar,Consultorios,https://www.casasyterrenos.com/jalisco/tonala/consultorios/venta
+casas_y_terrenos,Zapopan,Comprar,Consultorios,https://www.casasyterrenos.com/jalisco/zapopan/consultorios/venta
+casas_y_terrenos,Zapotlanejo,Comprar,Consultorios,https://www.casasyterrenos.com/jalisco/zapotlanejo/consultorios/venta
+casas_y_terrenos,El Salto,Rentar,Casas,https://www.casasyterrenos.com/jalisco/el-salto/casas/renta
+casas_y_terrenos,Guadalajara,Rentar,Casas,https://www.casasyterrenos.com/jalisco/guadalajara/casas/renta
+casas_y_terrenos,Ixtlahuacán de los Membrillos,Rentar,Casas,https://www.casasyterrenos.com/jalisco/ixtlahuacan-de-los-membrillos/casas/renta
+casas_y_terrenos,Juanacatlán,Rentar,Casas,https://www.casasyterrenos.com/jalisco/juanacatlan/casas/renta
+casas_y_terrenos,Tlajomulco de Zúñiga,Rentar,Casas,https://www.casasyterrenos.com/jalisco/tlajomulco-de-zuniga/casas/renta
+casas_y_terrenos,San Pedro Tlaquepaque,Rentar,Casas,https://www.casasyterrenos.com/jalisco/tlaquepaque/casas/renta
+casas_y_terrenos,Tonalá,Rentar,Casas,https://www.casasyterrenos.com/jalisco/tonala/casas/renta
+casas_y_terrenos,Zapopan,Rentar,Casas,https://www.casasyterrenos.com/jalisco/zapopan/casas/renta
+casas_y_terrenos,Zapotlanejo,Rentar,Casas,https://www.casasyterrenos.com/jalisco/zapotlanejo/casas/renta
+casas_y_terrenos,El Salto,Comprar,Casas,https://www.casasyterrenos.com/jalisco/el-salto/casas/venta
+casas_y_terrenos,Guadalajara,Comprar,Casas,https://www.casasyterrenos.com/jalisco/guadalajara/casas/venta
+casas_y_terrenos,Ixtlahuacán de los Membrillos,Comprar,Casas,https://www.casasyterrenos.com/jalisco/ixtlahuacan-de-los-membrillos/casas/venta
+casas_y_terrenos,Juanacatlán,Comprar,Casas,https://www.casasyterrenos.com/jalisco/juanacatlan/casas/venta
+casas_y_terrenos,Tlajomulco de Zúñiga,Comprar,Casas,https://www.casasyterrenos.com/jalisco/tlajomulco-de-zuniga/casas/venta
+casas_y_terrenos,San Pedro Tlaquepaque,Comprar,Casas,https://www.casasyterrenos.com/jalisco/tlaquepaque/casas/venta
+casas_y_terrenos,Tonalá,Comprar,Casas,https://www.casasyterrenos.com/jalisco/tonala/casas/venta
+casas_y_terrenos,Zapopan,Comprar,Casas,https://www.casasyterrenos.com/jalisco/zapopan/casas/venta
+casas_y_terrenos,Zapotlanejo,Comprar,Casas,https://www.casasyterrenos.com/jalisco/zapotlanejo/casas/venta
+casas_y_terrenos,El Salto,Rentar,Bodegas,https://www.casasyterrenos.com/jalisco/el-salto/bodegas/renta
+casas_y_terrenos,Guadalajara,Rentar,Bodegas,https://www.casasyterrenos.com/jalisco/guadalajara/bodegas/renta
+casas_y_terrenos,Ixtlahuacán de los Membrillos,Rentar,Bodegas,https://www.casasyterrenos.com/jalisco/ixtlahuacan-de-los-membrillos/bodegas/renta
+casas_y_terrenos,Juanacatlán,Rentar,Bodegas,https://www.casasyterrenos.com/jalisco/juanacatlan/bodegas/renta
+casas_y_terrenos,Tlajomulco de Zúñiga,Rentar,Bodegas,https://www.casasyterrenos.com/jalisco/tlajomulco-de-zuniga/bodegas/renta
+casas_y_terrenos,San Pedro Tlaquepaque,Rentar,Bodegas,https://www.casasyterrenos.com/jalisco/tlaquepaque/bodegas/renta
+casas_y_terrenos,Tonalá,Rentar,Bodegas,https://www.casasyterrenos.com/jalisco/tonala/bodegas/renta
+casas_y_terrenos,Zapopan,Rentar,Bodegas,https://www.casasyterrenos.com/jalisco/zapopan/bodegas/renta
+casas_y_terrenos,Zapotlanejo,Rentar,Bodegas,https://www.casasyterrenos.com/jalisco/zapotlanejo/bodegas/renta
+casas_y_terrenos,El Salto,Comprar,Bodegas,https://www.casasyterrenos.com/jalisco/el-salto/bodegas/venta
+casas_y_terrenos,Guadalajara,Comprar,Bodegas,https://www.casasyterrenos.com/jalisco/guadalajara/bodegas/venta
+casas_y_terrenos,Ixtlahuacán de los Membrillos,Comprar,Bodegas,https://www.casasyterrenos.com/jalisco/ixtlahuacan-de-los-membrillos/bodegas/venta
+casas_y_terrenos,Juanacatlán,Comprar,Bodegas,https://www.casasyterrenos.com/jalisco/juanacatlan/bodegas/venta
+casas_y_terrenos,Tlajomulco de Zúñiga,Comprar,Bodegas,https://www.casasyterrenos.com/jalisco/tlajomulco-de-zuniga/bodegas/venta
+casas_y_terrenos,San Pedro Tlaquepaque,Comprar,Bodegas,https://www.casasyterrenos.com/jalisco/tlaquepaque/bodegas/venta
+casas_y_terrenos,Tonalá,Comprar,Bodegas,https://www.casasyterrenos.com/jalisco/tonala/bodegas/venta
+casas_y_terrenos,Zapopan,Comprar,Bodegas,https://www.casasyterrenos.com/jalisco/zapopan/bodegas/venta
+casas_y_terrenos,Zapotlanejo,Comprar,Bodegas,https://www.casasyterrenos.com/jalisco/zapotlanejo/bodegas/venta

--- a/URLs/inm24_urls.csv
+++ b/URLs/inm24_urls.csv
@@ -1,623 +1,622 @@
-# Formato: PaginaWeb,Ciudad,Operación,ProductoPaginaWeb,URL
-PaginaWeb,Ciudad,Operación,ProductoPaginaWeb,URL,ago25_2,sep25_1,sep25_2,oct25_1,oct25_2,nov25_1,nov25_2,dic25_1,dic25_2,ene25_1,ene25_2,feb25_1,feb25_2,mar25_1,mar25_2,abr25_1,abr25_2,may25_1,may25_2,jun25_1,jun25_2,jul25_1,jul25_2,ago25_1,ago25_2,sep25_1,sep25_2,,,,
-Inmuebles24,Zapopan,venta,Bodegas comerciales,https://www.inmuebles24.com/bodegas-comerciales-en-venta-en-zapopan.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Guadalajara,venta,Bodegas comerciales,https://www.inmuebles24.com/bodegas-comerciales-en-venta-en-guadalajara.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,San Pedro Tlaquepaque,venta,Bodegas comerciales,https://www.inmuebles24.com/bodegas-comerciales-en-venta-en-san-pedro-tlaquepaque.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,TonalÃ¡,venta,Bodegas comerciales,https://www.inmuebles24.com/bodegas-comerciales-en-venta-en-tonala.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapotlanejo,venta,Bodegas comerciales,https://www.inmuebles24.com/bodegas-comerciales-en-venta-en-zapotlanejo.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,JuanacatlÃ¡n,venta,Bodegas comerciales,https://www.inmuebles24.com/bodegas-comerciales-en-venta-en-juanacatlan.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,IxtlahuacÃ¡n de los Membrillos,venta,Bodegas comerciales,https://www.inmuebles24.com/bodegas-comerciales-en-venta-en-ixtlahuacan-de-los-membrillos.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,El Salto,venta,Bodegas comerciales,https://www.inmuebles24.com/bodegas-comerciales-en-venta-en-el-salto.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Tlajomulco de ZuÃ±iga,venta,Bodegas comerciales,https://www.inmuebles24.com/bodegas-comerciales-en-venta-en-tlajomulco-de-zuniga.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapopan,venta,Casa en condominio,https://www.inmuebles24.com/casa-en-condominio-en-venta-en-zapopan.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Guadalajara,venta,Casa en condominio,https://www.inmuebles24.com/casa-en-condominio-en-venta-en-guadalajara.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,San Pedro Tlaquepaque,venta,Casa en condominio,https://www.inmuebles24.com/casa-en-condominio-en-venta-en-san-pedro-tlaquepaque.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,TonalÃ¡,venta,Casa en condominio,https://www.inmuebles24.com/casa-en-condominio-en-venta-en-tonala.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapotlanejo,venta,Casa en condominio,https://www.inmuebles24.com/casa-en-condominio-en-venta-en-zapotlanejo.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,JuanacatlÃ¡n,venta,Casa en condominio,https://www.inmuebles24.com/casa-en-condominio-en-venta-en-juanacatlan.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,IxtlahuacÃ¡n de los Membrillos,venta,Casa en condominio,https://www.inmuebles24.com/casa-en-condominio-en-venta-en-ixtlahuacan-de-los-membrillos.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,El Salto,venta,Casa en condominio,https://www.inmuebles24.com/casa-en-condominio-en-venta-en-el-salto.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Tlajomulco de ZuÃ±iga,venta,Casa en condominio,https://www.inmuebles24.com/casa-en-condominio-en-venta-en-tlajomulco-de-zuniga.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapopan,venta,Casa uso de suelo,https://www.inmuebles24.com/casa-uso-de-suelo-en-venta-en-zapopan.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Guadalajara,venta,Casa uso de suelo,https://www.inmuebles24.com/casa-uso-de-suelo-en-venta-en-guadalajara.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,San Pedro Tlaquepaque,venta,Casa uso de suelo,https://www.inmuebles24.com/casa-uso-de-suelo-en-venta-en-san-pedro-tlaquepaque.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,TonalÃ¡,venta,Casa uso de suelo,https://www.inmuebles24.com/casa-uso-de-suelo-en-venta-en-tonala.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapotlanejo,venta,Casa uso de suelo,https://www.inmuebles24.com/casa-uso-de-suelo-en-venta-en-zapotlanejo.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,JuanacatlÃ¡n,venta,Casa uso de suelo,https://www.inmuebles24.com/casa-uso-de-suelo-en-venta-en-juanacatlan.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,IxtlahuacÃ¡n de los Membrillos,venta,Casa uso de suelo,https://www.inmuebles24.com/casa-uso-de-suelo-en-venta-en-ixtlahuacan-de-los-membrillos.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,El Salto,venta,Casa uso de suelo,https://www.inmuebles24.com/casa-uso-de-suelo-en-venta-en-el-salto.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Tlajomulco de ZuÃ±iga,venta,Casa uso de suelo,https://www.inmuebles24.com/casa-uso-de-suelo-en-venta-en-tlajomulco-de-zuniga.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapopan,venta,Casas,https://www.inmuebles24.com/casas-en-venta-en-zapopan.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Guadalajara,venta,Casas,https://www.inmuebles24.com/casas-en-venta-en-guadalajara.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,San Pedro Tlaquepaque,venta,Casas,https://www.inmuebles24.com/casas-en-venta-en-san-pedro-tlaquepaque.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,TonalÃ¡,venta,Casas,https://www.inmuebles24.com/casas-en-venta-en-tonala.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapotlanejo,venta,Casas,https://www.inmuebles24.com/casas-en-venta-en-zapotlanejo.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,JuanacatlÃ¡n,venta,Casas,https://www.inmuebles24.com/casas-en-venta-en-juanacatlan.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,IxtlahuacÃ¡n de los Membrillos,venta,Casas,https://www.inmuebles24.com/casas-en-venta-en-ixtlahuacan-de-los-membrillos.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,El Salto,venta,Casas,https://www.inmuebles24.com/casas-en-venta-en-el-salto.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Tlajomulco de ZuÃ±iga,venta,Casas,https://www.inmuebles24.com/casas-en-venta-en-tlajomulco-de-zuniga.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapopan,venta,DÃºplex,https://www.inmuebles24.com/duplex-en-venta-en-zapopan.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Guadalajara,venta,DÃºplex,https://www.inmuebles24.com/duplex-en-venta-en-guadalajara.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,San Pedro Tlaquepaque,venta,DÃºplex,https://www.inmuebles24.com/duplex-en-venta-en-san-pedro-tlaquepaque.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,TonalÃ¡,venta,DÃºplex,https://www.inmuebles24.com/duplex-en-venta-en-tonala.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapotlanejo,venta,DÃºplex,https://www.inmuebles24.com/duplex-en-venta-en-zapotlanejo.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,JuanacatlÃ¡n,venta,DÃºplex,https://www.inmuebles24.com/duplex-en-venta-en-juanacatlan.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,IxtlahuacÃ¡n de los Membrillos,venta,DÃºplex,https://www.inmuebles24.com/duplex-en-venta-en-ixtlahuacan-de-los-membrillos.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,El Salto,venta,DÃºplex,https://www.inmuebles24.com/duplex-en-venta-en-el-salto.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Tlajomulco de ZuÃ±iga,venta,DÃºplex,https://www.inmuebles24.com/duplex-en-venta-en-tlajomulco-de-zuniga.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapopan,venta,Departamento compartido,https://www.inmuebles24.com/departamento-compartido-en-venta-en-zapopan.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Guadalajara,venta,Departamento compartido,https://www.inmuebles24.com/departamento-compartido-en-venta-en-guadalajara.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,San Pedro Tlaquepaque,venta,Departamento compartido,https://www.inmuebles24.com/departamento-compartido-en-venta-en-san-pedro-tlaquepaque.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,TonalÃ¡,venta,Departamento compartido,https://www.inmuebles24.com/departamento-compartido-en-venta-en-tonala.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapotlanejo,venta,Departamento compartido,https://www.inmuebles24.com/departamento-compartido-en-venta-en-zapotlanejo.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,JuanacatlÃ¡n,venta,Departamento compartido,https://www.inmuebles24.com/departamento-compartido-en-venta-en-juanacatlan.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,IxtlahuacÃ¡n de los Membrillos,venta,Departamento compartido,https://www.inmuebles24.com/departamento-compartido-en-venta-en-ixtlahuacan-de-los-membrillos.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,El Salto,venta,Departamento compartido,https://www.inmuebles24.com/departamento-compartido-en-venta-en-el-salto.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Tlajomulco de ZuÃ±iga,venta,Departamento compartido,https://www.inmuebles24.com/departamento-compartido-en-venta-en-tlajomulco-de-zuniga.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapopan,venta,Departamentos,https://www.inmuebles24.com/departamentos-en-venta-en-zapopan.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Guadalajara,venta,Departamentos,https://www.inmuebles24.com/departamentos-en-venta-en-guadalajara.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,San Pedro Tlaquepaque,venta,Departamentos,https://www.inmuebles24.com/departamentos-en-venta-en-san-pedro-tlaquepaque.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,TonalÃ¡,venta,Departamentos,https://www.inmuebles24.com/departamentos-en-venta-en-tonala.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapotlanejo,venta,Departamentos,https://www.inmuebles24.com/departamentos-en-venta-en-zapotlanejo.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,JuanacatlÃ¡n,venta,Departamentos,https://www.inmuebles24.com/departamentos-en-venta-en-juanacatlan.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,IxtlahuacÃ¡n de los Membrillos,venta,Departamentos,https://www.inmuebles24.com/departamentos-en-venta-en-ixtlahuacan-de-los-membrillos.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,El Salto,venta,Departamentos,https://www.inmuebles24.com/departamentos-en-venta-en-el-salto.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Tlajomulco de ZuÃ±iga,venta,Departamentos,https://www.inmuebles24.com/departamentos-en-venta-en-tlajomulco-de-zuniga.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapopan,venta-d,Desarrollo horizontal,https://www.inmuebles24.com/desarrollo-horizontal-en-venta-en-zapopan.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Guadalajara,venta-d,Desarrollo horizontal,https://www.inmuebles24.com/desarrollo-horizontal-en-venta-en-guadalajara.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,San Pedro Tlaquepaque,venta-d,Desarrollo horizontal,https://www.inmuebles24.com/desarrollo-horizontal-en-venta-en-san-pedro-tlaquepaque.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,TonalÃ¡,venta-d,Desarrollo horizontal,https://www.inmuebles24.com/desarrollo-horizontal-en-venta-en-tonala.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapotlanejo,venta-d,Desarrollo horizontal,https://www.inmuebles24.com/desarrollo-horizontal-en-venta-en-zapotlanejo.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,JuanacatlÃ¡n,venta-d,Desarrollo horizontal,https://www.inmuebles24.com/desarrollo-horizontal-en-venta-en-juanacatlan.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,IxtlahuacÃ¡n de los Membrillos,venta-d,Desarrollo horizontal,https://www.inmuebles24.com/desarrollo-horizontal-en-venta-en-ixtlahuacan-de-los-membrillos.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,El Salto,venta-d,Desarrollo horizontal,https://www.inmuebles24.com/desarrollo-horizontal-en-venta-en-el-salto.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Tlajomulco de ZuÃ±iga,venta-d,Desarrollo horizontal,https://www.inmuebles24.com/desarrollo-horizontal-en-venta-en-tlajomulco-de-zuniga.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapopan,venta-d,Desarrollo horizontal/vertical,https://www.inmuebles24.com/desarrollo-horizontal-vertical-en-venta-en-zapopan.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Guadalajara,venta-d,Desarrollo horizontal/vertical,https://www.inmuebles24.com/desarrollo-horizontal-vertical-en-venta-en-guadalajara.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,San Pedro Tlaquepaque,venta-d,Desarrollo horizontal/vertical,https://www.inmuebles24.com/desarrollo-horizontal-vertical-en-venta-en-san-pedro-tlaquepaque.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,TonalÃ¡,venta-d,Desarrollo horizontal/vertical,https://www.inmuebles24.com/desarrollo-horizontal-vertical-en-venta-en-tonala.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapotlanejo,venta-d,Desarrollo horizontal/vertical,https://www.inmuebles24.com/desarrollo-horizontal-vertical-en-venta-en-zapotlanejo.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,JuanacatlÃ¡n,venta-d,Desarrollo horizontal/vertical,https://www.inmuebles24.com/desarrollo-horizontal-vertical-en-venta-en-juanacatlan.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,IxtlahuacÃ¡n de los Membrillos,venta-d,Desarrollo horizontal/vertical,https://www.inmuebles24.com/desarrollo-horizontal-vertical-en-venta-en-ixtlahuacan-de-los-membrillos.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,El Salto,venta-d,Desarrollo horizontal/vertical,https://www.inmuebles24.com/desarrollo-horizontal-vertical-en-venta-en-el-salto.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Tlajomulco de ZuÃ±iga,venta-d,Desarrollo horizontal/vertical,https://www.inmuebles24.com/desarrollo-horizontal-vertical-en-venta-en-tlajomulco-de-zuniga.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapopan,venta-d,Desarrollo vertical,https://www.inmuebles24.com/desarrollo-vertical-en-venta-en-zapopan.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Guadalajara,venta-d,Desarrollo vertical,https://www.inmuebles24.com/desarrollo-vertical-en-venta-en-guadalajara.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,San Pedro Tlaquepaque,venta-d,Desarrollo vertical,https://www.inmuebles24.com/desarrollo-vertical-en-venta-en-san-pedro-tlaquepaque.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,TonalÃ¡,venta-d,Desarrollo vertical,https://www.inmuebles24.com/desarrollo-vertical-en-venta-en-tonala.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapotlanejo,venta-d,Desarrollo vertical,https://www.inmuebles24.com/desarrollo-vertical-en-venta-en-zapotlanejo.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,JuanacatlÃ¡n,venta-d,Desarrollo vertical,https://www.inmuebles24.com/desarrollo-vertical-en-venta-en-juanacatlan.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,IxtlahuacÃ¡n de los Membrillos,venta-d,Desarrollo vertical,https://www.inmuebles24.com/desarrollo-vertical-en-venta-en-ixtlahuacan-de-los-membrillos.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,El Salto,venta-d,Desarrollo vertical,https://www.inmuebles24.com/desarrollo-vertical-en-venta-en-el-salto.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Tlajomulco de ZuÃ±iga,venta-d,Desarrollo vertical,https://www.inmuebles24.com/desarrollo-vertical-en-venta-en-tlajomulco-de-zuniga.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapopan,venta,Edificio,https://www.inmuebles24.com/edificio-en-venta-en-zapopan.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Guadalajara,venta,Edificio,https://www.inmuebles24.com/edificio-en-venta-en-guadalajara.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,San Pedro Tlaquepaque,venta,Edificio,https://www.inmuebles24.com/edificio-en-venta-en-san-pedro-tlaquepaque.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,TonalÃ¡,venta,Edificio,https://www.inmuebles24.com/edificio-en-venta-en-tonala.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapotlanejo,venta,Edificio,https://www.inmuebles24.com/edificio-en-venta-en-zapotlanejo.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,JuanacatlÃ¡n,venta,Edificio,https://www.inmuebles24.com/edificio-en-venta-en-juanacatlan.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,IxtlahuacÃ¡n de los Membrillos,venta,Edificio,https://www.inmuebles24.com/edificio-en-venta-en-ixtlahuacan-de-los-membrillos.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,El Salto,venta,Edificio,https://www.inmuebles24.com/edificio-en-venta-en-el-salto.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Tlajomulco de ZuÃ±iga,venta,Edificio,https://www.inmuebles24.com/edificio-en-venta-en-tlajomulco-de-zuniga.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapopan,venta,Huerta,https://www.inmuebles24.com/huerta-en-venta-en-zapopan.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Guadalajara,venta,Huerta,https://www.inmuebles24.com/huerta-en-venta-en-guadalajara.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,San Pedro Tlaquepaque,venta,Huerta,https://www.inmuebles24.com/huerta-en-venta-en-san-pedro-tlaquepaque.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,TonalÃ¡,venta,Huerta,https://www.inmuebles24.com/huerta-en-venta-en-tonala.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapotlanejo,venta,Huerta,https://www.inmuebles24.com/huerta-en-venta-en-zapotlanejo.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,JuanacatlÃ¡n,venta,Huerta,https://www.inmuebles24.com/huerta-en-venta-en-juanacatlan.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,IxtlahuacÃ¡n de los Membrillos,venta,Huerta,https://www.inmuebles24.com/huerta-en-venta-en-ixtlahuacan-de-los-membrillos.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,El Salto,venta,Huerta,https://www.inmuebles24.com/huerta-en-venta-en-el-salto.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Tlajomulco de ZuÃ±iga,venta,Huerta,https://www.inmuebles24.com/huerta-en-venta-en-tlajomulco-de-zuniga.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapopan,venta,Inmueble productivo urbano,https://www.inmuebles24.com/inmueble-productivo-urbano-en-venta-en-zapopan.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Guadalajara,venta,Inmueble productivo urbano,https://www.inmuebles24.com/inmueble-productivo-urbano-en-venta-en-guadalajara.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,San Pedro Tlaquepaque,venta,Inmueble productivo urbano,https://www.inmuebles24.com/inmueble-productivo-urbano-en-venta-en-san-pedro-tlaquepaque.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,TonalÃ¡,venta,Inmueble productivo urbano,https://www.inmuebles24.com/inmueble-productivo-urbano-en-venta-en-tonala.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapotlanejo,venta,Inmueble productivo urbano,https://www.inmuebles24.com/inmueble-productivo-urbano-en-venta-en-zapotlanejo.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,JuanacatlÃ¡n,venta,Inmueble productivo urbano,https://www.inmuebles24.com/inmueble-productivo-urbano-en-venta-en-juanacatlan.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,IxtlahuacÃ¡n de los Membrillos,venta,Inmueble productivo urbano,https://www.inmuebles24.com/inmueble-productivo-urbano-en-venta-en-ixtlahuacan-de-los-membrillos.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,El Salto,venta,Inmueble productivo urbano,https://www.inmuebles24.com/inmueble-productivo-urbano-en-venta-en-el-salto.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Tlajomulco de ZuÃ±iga,venta,Inmueble productivo urbano,https://www.inmuebles24.com/inmueble-productivo-urbano-en-venta-en-tlajomulco-de-zuniga.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapopan,venta,Local en centro comercial,https://www.inmuebles24.com/local-en-centro-comercial-en-venta-en-zapopan.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Guadalajara,venta,Local en centro comercial,https://www.inmuebles24.com/local-en-centro-comercial-en-venta-en-guadalajara.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,San Pedro Tlaquepaque,venta,Local en centro comercial,https://www.inmuebles24.com/local-en-centro-comercial-en-venta-en-san-pedro-tlaquepaque.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,TonalÃ¡,venta,Local en centro comercial,https://www.inmuebles24.com/local-en-centro-comercial-en-venta-en-tonala.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapotlanejo,venta,Local en centro comercial,https://www.inmuebles24.com/local-en-centro-comercial-en-venta-en-zapotlanejo.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,JuanacatlÃ¡n,venta,Local en centro comercial,https://www.inmuebles24.com/local-en-centro-comercial-en-venta-en-juanacatlan.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,IxtlahuacÃ¡n de los Membrillos,venta,Local en centro comercial,https://www.inmuebles24.com/local-en-centro-comercial-en-venta-en-ixtlahuacan-de-los-membrillos.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,El Salto,venta,Local en centro comercial,https://www.inmuebles24.com/local-en-centro-comercial-en-venta-en-el-salto.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Tlajomulco de ZuÃ±iga,venta,Local en centro comercial,https://www.inmuebles24.com/local-en-centro-comercial-en-venta-en-tlajomulco-de-zuniga.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapopan,venta,Locales comerciales,https://www.inmuebles24.com/locales-comerciales-en-venta-en-zapopan.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Guadalajara,venta,Locales comerciales,https://www.inmuebles24.com/locales-comerciales-en-venta-en-guadalajara.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,San Pedro Tlaquepaque,venta,Locales comerciales,https://www.inmuebles24.com/locales-comerciales-en-venta-en-san-pedro-tlaquepaque.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,TonalÃ¡,venta,Locales comerciales,https://www.inmuebles24.com/locales-comerciales-en-venta-en-tonala.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapotlanejo,venta,Locales comerciales,https://www.inmuebles24.com/locales-comerciales-en-venta-en-zapotlanejo.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,JuanacatlÃ¡n,venta,Locales comerciales,https://www.inmuebles24.com/locales-comerciales-en-venta-en-juanacatlan.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,IxtlahuacÃ¡n de los Membrillos,venta,Locales comerciales,https://www.inmuebles24.com/locales-comerciales-en-venta-en-ixtlahuacan-de-los-membrillos.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,El Salto,venta,Locales comerciales,https://www.inmuebles24.com/locales-comerciales-en-venta-en-el-salto.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Tlajomulco de ZuÃ±iga,venta,Locales comerciales,https://www.inmuebles24.com/locales-comerciales-en-venta-en-tlajomulco-de-zuniga.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapopan,venta,Nave industrial,https://www.inmuebles24.com/nave-industrial-en-venta-en-zapopan.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Guadalajara,venta,Nave industrial,https://www.inmuebles24.com/nave-industrial-en-venta-en-guadalajara.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,San Pedro Tlaquepaque,venta,Nave industrial,https://www.inmuebles24.com/nave-industrial-en-venta-en-san-pedro-tlaquepaque.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,TonalÃ¡,venta,Nave industrial,https://www.inmuebles24.com/nave-industrial-en-venta-en-tonala.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapotlanejo,venta,Nave industrial,https://www.inmuebles24.com/nave-industrial-en-venta-en-zapotlanejo.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,JuanacatlÃ¡n,venta,Nave industrial,https://www.inmuebles24.com/nave-industrial-en-venta-en-juanacatlan.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,IxtlahuacÃ¡n de los Membrillos,venta,Nave industrial,https://www.inmuebles24.com/nave-industrial-en-venta-en-ixtlahuacan-de-los-membrillos.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,El Salto,venta,Nave industrial,https://www.inmuebles24.com/nave-industrial-en-venta-en-el-salto.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Tlajomulco de ZuÃ±iga,venta,Nave industrial,https://www.inmuebles24.com/nave-industrial-en-venta-en-tlajomulco-de-zuniga.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapopan,venta,Oficinas,https://www.inmuebles24.com/oficinas-en-venta-en-zapopan.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Guadalajara,venta,Oficinas,https://www.inmuebles24.com/oficinas-en-venta-en-guadalajara.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,San Pedro Tlaquepaque,venta,Oficinas,https://www.inmuebles24.com/oficinas-en-venta-en-san-pedro-tlaquepaque.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,TonalÃ¡,venta,Oficinas,https://www.inmuebles24.com/oficinas-en-venta-en-tonala.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapotlanejo,venta,Oficinas,https://www.inmuebles24.com/oficinas-en-venta-en-zapotlanejo.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,JuanacatlÃ¡n,venta,Oficinas,https://www.inmuebles24.com/oficinas-en-venta-en-juanacatlan.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,IxtlahuacÃ¡n de los Membrillos,venta,Oficinas,https://www.inmuebles24.com/oficinas-en-venta-en-ixtlahuacan-de-los-membrillos.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,El Salto,venta,Oficinas,https://www.inmuebles24.com/oficinas-en-venta-en-el-salto.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Tlajomulco de ZuÃ±iga,venta,Oficinas,https://www.inmuebles24.com/oficinas-en-venta-en-tlajomulco-de-zuniga.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapopan,venta,Quinta,https://www.inmuebles24.com/quinta-en-venta-en-zapopan.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Guadalajara,venta,Quinta,https://www.inmuebles24.com/quinta-en-venta-en-guadalajara.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,San Pedro Tlaquepaque,venta,Quinta,https://www.inmuebles24.com/quinta-en-venta-en-san-pedro-tlaquepaque.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,TonalÃ¡,venta,Quinta,https://www.inmuebles24.com/quinta-en-venta-en-tonala.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapotlanejo,venta,Quinta,https://www.inmuebles24.com/quinta-en-venta-en-zapotlanejo.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,JuanacatlÃ¡n,venta,Quinta,https://www.inmuebles24.com/quinta-en-venta-en-juanacatlan.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,IxtlahuacÃ¡n de los Membrillos,venta,Quinta,https://www.inmuebles24.com/quinta-en-venta-en-ixtlahuacan-de-los-membrillos.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,El Salto,venta,Quinta,https://www.inmuebles24.com/quinta-en-venta-en-el-salto.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Tlajomulco de ZuÃ±iga,venta,Quinta,https://www.inmuebles24.com/quinta-en-venta-en-tlajomulco-de-zuniga.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapopan,venta,Terreno comercial,https://www.inmuebles24.com/terreno-comercial-en-venta-en-zapopan.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Guadalajara,venta,Terreno comercial,https://www.inmuebles24.com/terreno-comercial-en-venta-en-guadalajara.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,San Pedro Tlaquepaque,venta,Terreno comercial,https://www.inmuebles24.com/terreno-comercial-en-venta-en-san-pedro-tlaquepaque.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,TonalÃ¡,venta,Terreno comercial,https://www.inmuebles24.com/terreno-comercial-en-venta-en-tonala.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapotlanejo,venta,Terreno comercial,https://www.inmuebles24.com/terreno-comercial-en-venta-en-zapotlanejo.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,JuanacatlÃ¡n,venta,Terreno comercial,https://www.inmuebles24.com/terreno-comercial-en-venta-en-juanacatlan.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,IxtlahuacÃ¡n de los Membrillos,venta,Terreno comercial,https://www.inmuebles24.com/terreno-comercial-en-venta-en-ixtlahuacan-de-los-membrillos.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,El Salto,venta,Terreno comercial,https://www.inmuebles24.com/terreno-comercial-en-venta-en-el-salto.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Tlajomulco de ZuÃ±iga,venta,Terreno comercial,https://www.inmuebles24.com/terreno-comercial-en-venta-en-tlajomulco-de-zuniga.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapopan,venta,Terreno industrial,https://www.inmuebles24.com/terreno-industrial-en-venta-en-zapopan.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Guadalajara,venta,Terreno industrial,https://www.inmuebles24.com/terreno-industrial-en-venta-en-guadalajara.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,San Pedro Tlaquepaque,venta,Terreno industrial,https://www.inmuebles24.com/terreno-industrial-en-venta-en-san-pedro-tlaquepaque.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,TonalÃ¡,venta,Terreno industrial,https://www.inmuebles24.com/terreno-industrial-en-venta-en-tonala.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapotlanejo,venta,Terreno industrial,https://www.inmuebles24.com/terreno-industrial-en-venta-en-zapotlanejo.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,JuanacatlÃ¡n,venta,Terreno industrial,https://www.inmuebles24.com/terreno-industrial-en-venta-en-juanacatlan.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,IxtlahuacÃ¡n de los Membrillos,venta,Terreno industrial,https://www.inmuebles24.com/terreno-industrial-en-venta-en-ixtlahuacan-de-los-membrillos.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,El Salto,venta,Terreno industrial,https://www.inmuebles24.com/terreno-industrial-en-venta-en-el-salto.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Tlajomulco de ZuÃ±iga,venta,Terreno industrial,https://www.inmuebles24.com/terreno-industrial-en-venta-en-tlajomulco-de-zuniga.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapopan,venta,Terrenos,https://www.inmuebles24.com/terrenos-en-venta-en-zapopan.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Guadalajara,venta,Terrenos,https://www.inmuebles24.com/terrenos-en-venta-en-guadalajara.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,San Pedro Tlaquepaque,venta,Terrenos,https://www.inmuebles24.com/terrenos-en-venta-en-san-pedro-tlaquepaque.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,TonalÃ¡,venta,Terrenos,https://www.inmuebles24.com/terrenos-en-venta-en-tonala.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapotlanejo,venta,Terrenos,https://www.inmuebles24.com/terrenos-en-venta-en-zapotlanejo.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,JuanacatlÃ¡n,venta,Terrenos,https://www.inmuebles24.com/terrenos-en-venta-en-juanacatlan.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,IxtlahuacÃ¡n de los Membrillos,venta,Terrenos,https://www.inmuebles24.com/terrenos-en-venta-en-ixtlahuacan-de-los-membrillos.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,El Salto,venta,Terrenos,https://www.inmuebles24.com/terrenos-en-venta-en-el-salto.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Tlajomulco de ZuÃ±iga,venta,Terrenos,https://www.inmuebles24.com/terrenos-en-venta-en-tlajomulco-de-zuniga.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapopan,venta,Villa,https://www.inmuebles24.com/villa-en-venta-en-zapopan.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Guadalajara,venta,Villa,https://www.inmuebles24.com/villa-en-venta-en-guadalajara.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,San Pedro Tlaquepaque,venta,Villa,https://www.inmuebles24.com/villa-en-venta-en-san-pedro-tlaquepaque.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,TonalÃ¡,venta,Villa,https://www.inmuebles24.com/villa-en-venta-en-tonala.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapotlanejo,venta,Villa,https://www.inmuebles24.com/villa-en-venta-en-zapotlanejo.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,JuanacatlÃ¡n,venta,Villa,https://www.inmuebles24.com/villa-en-venta-en-juanacatlan.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,IxtlahuacÃ¡n de los Membrillos,venta,Villa,https://www.inmuebles24.com/villa-en-venta-en-ixtlahuacan-de-los-membrillos.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,El Salto,venta,Villa,https://www.inmuebles24.com/villa-en-venta-en-el-salto.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Tlajomulco de ZuÃ±iga,venta,Villa,https://www.inmuebles24.com/villa-en-venta-en-tlajomulco-de-zuniga.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapopan,venta-d,Desarrollo horizontal,https://www.inmuebles24.com/desarrollo-horizontal-en-venta-en-zapopan.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Guadalajara,venta-d,Desarrollo horizontal,https://www.inmuebles24.com/desarrollo-horizontal-en-venta-en-guadalajara.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,San Pedro Tlaquepaque,venta-d,Desarrollo horizontal,https://www.inmuebles24.com/desarrollo-horizontal-en-venta-en-san-pedro-tlaquepaque.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,TonalÃ¡,venta-d,Desarrollo horizontal,https://www.inmuebles24.com/desarrollo-horizontal-en-venta-en-tonala.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapotlanejo,venta-d,Desarrollo horizontal,https://www.inmuebles24.com/desarrollo-horizontal-en-venta-en-zapotlanejo.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,JuanacatlÃ¡n,venta-d,Desarrollo horizontal,https://www.inmuebles24.com/desarrollo-horizontal-en-venta-en-juanacatlan.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,IxtlahuacÃ¡n de los Membrillos,venta-d,Desarrollo horizontal,https://www.inmuebles24.com/desarrollo-horizontal-en-venta-en-ixtlahuacan-de-los-membrillos.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,El Salto,venta-d,Desarrollo horizontal,https://www.inmuebles24.com/desarrollo-horizontal-en-venta-en-el-salto.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Tlajomulco de ZuÃ±iga,venta-d,Desarrollo horizontal,https://www.inmuebles24.com/desarrollo-horizontal-en-venta-en-tlajomulco-de-zuniga.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapopan,venta-d,Desarrollo horizontal/vertical,https://www.inmuebles24.com/desarrollo-horizontal-vertical-en-venta-en-zapopan.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Guadalajara,venta-d,Desarrollo horizontal/vertical,https://www.inmuebles24.com/desarrollo-horizontal-vertical-en-venta-en-guadalajara.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,San Pedro Tlaquepaque,venta-d,Desarrollo horizontal/vertical,https://www.inmuebles24.com/desarrollo-horizontal-vertical-en-venta-en-san-pedro-tlaquepaque.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,TonalÃ¡,venta-d,Desarrollo horizontal/vertical,https://www.inmuebles24.com/desarrollo-horizontal-vertical-en-venta-en-tonala.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapotlanejo,venta-d,Desarrollo horizontal/vertical,https://www.inmuebles24.com/desarrollo-horizontal-vertical-en-venta-en-zapotlanejo.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,JuanacatlÃ¡n,venta-d,Desarrollo horizontal/vertical,https://www.inmuebles24.com/desarrollo-horizontal-vertical-en-venta-en-juanacatlan.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,IxtlahuacÃ¡n de los Membrillos,venta-d,Desarrollo horizontal/vertical,https://www.inmuebles24.com/desarrollo-horizontal-vertical-en-venta-en-ixtlahuacan-de-los-membrillos.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,El Salto,venta-d,Desarrollo horizontal/vertical,https://www.inmuebles24.com/desarrollo-horizontal-vertical-en-venta-en-el-salto.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Tlajomulco de ZuÃ±iga,venta-d,Desarrollo horizontal/vertical,https://www.inmuebles24.com/desarrollo-horizontal-vertical-en-venta-en-tlajomulco-de-zuniga.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapopan,venta-d,Desarrollo vertical,https://www.inmuebles24.com/desarrollo-vertical-en-venta-en-zapopan.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Guadalajara,venta-d,Desarrollo vertical,https://www.inmuebles24.com/desarrollo-vertical-en-venta-en-guadalajara.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,San Pedro Tlaquepaque,venta-d,Desarrollo vertical,https://www.inmuebles24.com/desarrollo-vertical-en-venta-en-san-pedro-tlaquepaque.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,TonalÃ¡,venta-d,Desarrollo vertical,https://www.inmuebles24.com/desarrollo-vertical-en-venta-en-tonala.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapotlanejo,venta-d,Desarrollo vertical,https://www.inmuebles24.com/desarrollo-vertical-en-venta-en-zapotlanejo.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,JuanacatlÃ¡n,venta-d,Desarrollo vertical,https://www.inmuebles24.com/desarrollo-vertical-en-venta-en-juanacatlan.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,IxtlahuacÃ¡n de los Membrillos,venta-d,Desarrollo vertical,https://www.inmuebles24.com/desarrollo-vertical-en-venta-en-ixtlahuacan-de-los-membrillos.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,El Salto,venta-d,Desarrollo vertical,https://www.inmuebles24.com/desarrollo-vertical-en-venta-en-el-salto.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Tlajomulco de ZuÃ±iga,venta-d,Desarrollo vertical,https://www.inmuebles24.com/desarrollo-vertical-en-venta-en-tlajomulco-de-zuniga.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapopan,venta-r,Bodegas comerciales,https://www.inmuebles24.com/bodegas-comerciales-en-venta-en-zapopan-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Guadalajara,venta-r,Bodegas comerciales,https://www.inmuebles24.com/bodegas-comerciales-en-venta-en-guadalajara-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,San Pedro Tlaquepaque,venta-r,Bodegas comerciales,https://www.inmuebles24.com/bodegas-comerciales-en-venta-en-san-pedro-tlaquepaque-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,TonalÃ¡,venta-r,Bodegas comerciales,https://www.inmuebles24.com/bodegas-comerciales-en-venta-en-tonala-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapotlanejo,venta-r,Bodegas comerciales,https://www.inmuebles24.com/bodegas-comerciales-en-venta-en-zapotlanejo-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,JuanacatlÃ¡n,venta-r,Bodegas comerciales,https://www.inmuebles24.com/bodegas-comerciales-en-venta-en-juanacatlan-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,IxtlahuacÃ¡n de los Membrillos,venta-r,Bodegas comerciales,https://www.inmuebles24.com/bodegas-comerciales-en-venta-en-ixtlahuacan-de-los-membrillos-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,El Salto,venta-r,Bodegas comerciales,https://www.inmuebles24.com/bodegas-comerciales-en-venta-en-el-salto-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Tlajomulco de ZuÃ±iga,venta-r,Bodegas comerciales,https://www.inmuebles24.com/bodegas-comerciales-en-venta-en-tlajomulco-de-zuniga-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapopan,venta-r,Casa en condominio,https://www.inmuebles24.com/casa-en-condominio-en-venta-en-zapopan-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Guadalajara,venta-r,Casa en condominio,https://www.inmuebles24.com/casa-en-condominio-en-venta-en-guadalajara-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,San Pedro Tlaquepaque,venta-r,Casa en condominio,https://www.inmuebles24.com/casa-en-condominio-en-venta-en-san-pedro-tlaquepaque-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,TonalÃ¡,venta-r,Casa en condominio,https://www.inmuebles24.com/casa-en-condominio-en-venta-en-tonala-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapotlanejo,venta-r,Casa en condominio,https://www.inmuebles24.com/casa-en-condominio-en-venta-en-zapotlanejo-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,JuanacatlÃ¡n,venta-r,Casa en condominio,https://www.inmuebles24.com/casa-en-condominio-en-venta-en-juanacatlan-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,IxtlahuacÃ¡n de los Membrillos,venta-r,Casa en condominio,https://www.inmuebles24.com/casa-en-condominio-en-venta-en-ixtlahuacan-de-los-membrillos-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,El Salto,venta-r,Casa en condominio,https://www.inmuebles24.com/casa-en-condominio-en-venta-en-el-salto-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Tlajomulco de ZuÃ±iga,venta-r,Casa en condominio,https://www.inmuebles24.com/casa-en-condominio-en-venta-en-tlajomulco-de-zuniga-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapopan,venta-r,Casa uso de suelo,https://www.inmuebles24.com/casa-uso-de-suelo-en-venta-en-zapopan-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Guadalajara,venta-r,Casa uso de suelo,https://www.inmuebles24.com/casa-uso-de-suelo-en-venta-en-guadalajara-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,San Pedro Tlaquepaque,venta-r,Casa uso de suelo,https://www.inmuebles24.com/casa-uso-de-suelo-en-venta-en-san-pedro-tlaquepaque-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,TonalÃ¡,venta-r,Casa uso de suelo,https://www.inmuebles24.com/casa-uso-de-suelo-en-venta-en-tonala-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapotlanejo,venta-r,Casa uso de suelo,https://www.inmuebles24.com/casa-uso-de-suelo-en-venta-en-zapotlanejo-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,JuanacatlÃ¡n,venta-r,Casa uso de suelo,https://www.inmuebles24.com/casa-uso-de-suelo-en-venta-en-juanacatlan-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,IxtlahuacÃ¡n de los Membrillos,venta-r,Casa uso de suelo,https://www.inmuebles24.com/casa-uso-de-suelo-en-venta-en-ixtlahuacan-de-los-membrillos-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,El Salto,venta-r,Casa uso de suelo,https://www.inmuebles24.com/casa-uso-de-suelo-en-venta-en-el-salto-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Tlajomulco de ZuÃ±iga,venta-r,Casa uso de suelo,https://www.inmuebles24.com/casa-uso-de-suelo-en-venta-en-tlajomulco-de-zuniga-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapopan,venta-r,Casas,https://www.inmuebles24.com/casas-en-venta-en-zapopan-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Guadalajara,venta-r,Casas,https://www.inmuebles24.com/casas-en-venta-en-guadalajara-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,San Pedro Tlaquepaque,venta-r,Casas,https://www.inmuebles24.com/casas-en-venta-en-san-pedro-tlaquepaque-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,TonalÃ¡,venta-r,Casas,https://www.inmuebles24.com/casas-en-venta-en-tonala-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapotlanejo,venta-r,Casas,https://www.inmuebles24.com/casas-en-venta-en-zapotlanejo-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,JuanacatlÃ¡n,venta-r,Casas,https://www.inmuebles24.com/casas-en-venta-en-juanacatlan-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,IxtlahuacÃ¡n de los Membrillos,venta-r,Casas,https://www.inmuebles24.com/casas-en-venta-en-ixtlahuacan-de-los-membrillos-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,El Salto,venta-r,Casas,https://www.inmuebles24.com/casas-en-venta-en-el-salto-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Tlajomulco de ZuÃ±iga,venta-r,Casas,https://www.inmuebles24.com/casas-en-venta-en-tlajomulco-de-zuniga-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapopan,venta-r,DÃºplex,https://www.inmuebles24.com/duplex-en-venta-en-zapopan-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Guadalajara,venta-r,DÃºplex,https://www.inmuebles24.com/duplex-en-venta-en-guadalajara-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,San Pedro Tlaquepaque,venta-r,DÃºplex,https://www.inmuebles24.com/duplex-en-venta-en-san-pedro-tlaquepaque-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,TonalÃ¡,venta-r,DÃºplex,https://www.inmuebles24.com/duplex-en-venta-en-tonala-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapotlanejo,venta-r,DÃºplex,https://www.inmuebles24.com/duplex-en-venta-en-zapotlanejo-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,JuanacatlÃ¡n,venta-r,DÃºplex,https://www.inmuebles24.com/duplex-en-venta-en-juanacatlan-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,IxtlahuacÃ¡n de los Membrillos,venta-r,DÃºplex,https://www.inmuebles24.com/duplex-en-venta-en-ixtlahuacan-de-los-membrillos-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,El Salto,venta-r,DÃºplex,https://www.inmuebles24.com/duplex-en-venta-en-el-salto-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Tlajomulco de ZuÃ±iga,venta-r,DÃºplex,https://www.inmuebles24.com/duplex-en-venta-en-tlajomulco-de-zuniga-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapopan,venta-r,Departamento compartido,https://www.inmuebles24.com/departamento-compartido-en-venta-en-zapopan-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Guadalajara,venta-r,Departamento compartido,https://www.inmuebles24.com/departamento-compartido-en-venta-en-guadalajara-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,San Pedro Tlaquepaque,venta-r,Departamento compartido,https://www.inmuebles24.com/departamento-compartido-en-venta-en-san-pedro-tlaquepaque-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,TonalÃ¡,venta-r,Departamento compartido,https://www.inmuebles24.com/departamento-compartido-en-venta-en-tonala-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapotlanejo,venta-r,Departamento compartido,https://www.inmuebles24.com/departamento-compartido-en-venta-en-zapotlanejo-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,JuanacatlÃ¡n,venta-r,Departamento compartido,https://www.inmuebles24.com/departamento-compartido-en-venta-en-juanacatlan-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,IxtlahuacÃ¡n de los Membrillos,venta-r,Departamento compartido,https://www.inmuebles24.com/departamento-compartido-en-venta-en-ixtlahuacan-de-los-membrillos-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,El Salto,venta-r,Departamento compartido,https://www.inmuebles24.com/departamento-compartido-en-venta-en-el-salto-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Tlajomulco de ZuÃ±iga,venta-r,Departamento compartido,https://www.inmuebles24.com/departamento-compartido-en-venta-en-tlajomulco-de-zuniga-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapopan,venta-r,Departamentos,https://www.inmuebles24.com/departamentos-en-venta-en-zapopan-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Guadalajara,venta-r,Departamentos,https://www.inmuebles24.com/departamentos-en-venta-en-guadalajara-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,San Pedro Tlaquepaque,venta-r,Departamentos,https://www.inmuebles24.com/departamentos-en-venta-en-san-pedro-tlaquepaque-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,TonalÃ¡,venta-r,Departamentos,https://www.inmuebles24.com/departamentos-en-venta-en-tonala-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapotlanejo,venta-r,Departamentos,https://www.inmuebles24.com/departamentos-en-venta-en-zapotlanejo-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,JuanacatlÃ¡n,venta-r,Departamentos,https://www.inmuebles24.com/departamentos-en-venta-en-juanacatlan-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,IxtlahuacÃ¡n de los Membrillos,venta-r,Departamentos,https://www.inmuebles24.com/departamentos-en-venta-en-ixtlahuacan-de-los-membrillos-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,El Salto,venta-r,Departamentos,https://www.inmuebles24.com/departamentos-en-venta-en-el-salto-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Tlajomulco de ZuÃ±iga,venta-r,Departamentos,https://www.inmuebles24.com/departamentos-en-venta-en-tlajomulco-de-zuniga-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapopan,venta-r,Desarrollo horizontal,https://www.inmuebles24.com/desarrollo-horizontal-en-venta-en-zapopan-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Guadalajara,venta-r,Desarrollo horizontal,https://www.inmuebles24.com/desarrollo-horizontal-en-venta-en-guadalajara-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,San Pedro Tlaquepaque,venta-r,Desarrollo horizontal,https://www.inmuebles24.com/desarrollo-horizontal-en-venta-en-san-pedro-tlaquepaque-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,TonalÃ¡,venta-r,Desarrollo horizontal,https://www.inmuebles24.com/desarrollo-horizontal-en-venta-en-tonala-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapotlanejo,venta-r,Desarrollo horizontal,https://www.inmuebles24.com/desarrollo-horizontal-en-venta-en-zapotlanejo-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,JuanacatlÃ¡n,venta-r,Desarrollo horizontal,https://www.inmuebles24.com/desarrollo-horizontal-en-venta-en-juanacatlan-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,IxtlahuacÃ¡n de los Membrillos,venta-r,Desarrollo horizontal,https://www.inmuebles24.com/desarrollo-horizontal-en-venta-en-ixtlahuacan-de-los-membrillos-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,El Salto,venta-r,Desarrollo horizontal,https://www.inmuebles24.com/desarrollo-horizontal-en-venta-en-el-salto-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Tlajomulco de ZuÃ±iga,venta-r,Desarrollo horizontal,https://www.inmuebles24.com/desarrollo-horizontal-en-venta-en-tlajomulco-de-zuniga-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapopan,venta-r,Desarrollo horizontal/vertical,https://www.inmuebles24.com/desarrollo-horizontal-vertical-en-venta-en-zapopan-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Guadalajara,venta-r,Desarrollo horizontal/vertical,https://www.inmuebles24.com/desarrollo-horizontal-vertical-en-venta-en-guadalajara-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,San Pedro Tlaquepaque,venta-r,Desarrollo horizontal/vertical,https://www.inmuebles24.com/desarrollo-horizontal-vertical-en-venta-en-san-pedro-tlaquepaque-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,TonalÃ¡,venta-r,Desarrollo horizontal/vertical,https://www.inmuebles24.com/desarrollo-horizontal-vertical-en-venta-en-tonala-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapotlanejo,venta-r,Desarrollo horizontal/vertical,https://www.inmuebles24.com/desarrollo-horizontal-vertical-en-venta-en-zapotlanejo-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,JuanacatlÃ¡n,venta-r,Desarrollo horizontal/vertical,https://www.inmuebles24.com/desarrollo-horizontal-vertical-en-venta-en-juanacatlan-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,IxtlahuacÃ¡n de los Membrillos,venta-r,Desarrollo horizontal/vertical,https://www.inmuebles24.com/desarrollo-horizontal-vertical-en-venta-en-ixtlahuacan-de-los-membrillos-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,El Salto,venta-r,Desarrollo horizontal/vertical,https://www.inmuebles24.com/desarrollo-horizontal-vertical-en-venta-en-el-salto-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Tlajomulco de ZuÃ±iga,venta-r,Desarrollo horizontal/vertical,https://www.inmuebles24.com/desarrollo-horizontal-vertical-en-venta-en-tlajomulco-de-zuniga-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapopan,venta-r,Desarrollo vertical,https://www.inmuebles24.com/desarrollo-vertical-en-venta-en-zapopan-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Guadalajara,venta-r,Desarrollo vertical,https://www.inmuebles24.com/desarrollo-vertical-en-venta-en-guadalajara-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,San Pedro Tlaquepaque,venta-r,Desarrollo vertical,https://www.inmuebles24.com/desarrollo-vertical-en-venta-en-san-pedro-tlaquepaque-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,TonalÃ¡,venta-r,Desarrollo vertical,https://www.inmuebles24.com/desarrollo-vertical-en-venta-en-tonala-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapotlanejo,venta-r,Desarrollo vertical,https://www.inmuebles24.com/desarrollo-vertical-en-venta-en-zapotlanejo-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,JuanacatlÃ¡n,venta-r,Desarrollo vertical,https://www.inmuebles24.com/desarrollo-vertical-en-venta-en-juanacatlan-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,IxtlahuacÃ¡n de los Membrillos,venta-r,Desarrollo vertical,https://www.inmuebles24.com/desarrollo-vertical-en-venta-en-ixtlahuacan-de-los-membrillos-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,El Salto,venta-r,Desarrollo vertical,https://www.inmuebles24.com/desarrollo-vertical-en-venta-en-el-salto-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Tlajomulco de ZuÃ±iga,venta-r,Desarrollo vertical,https://www.inmuebles24.com/desarrollo-vertical-en-venta-en-tlajomulco-de-zuniga-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapopan,venta-r,Edificio,https://www.inmuebles24.com/edificio-en-venta-en-zapopan-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Guadalajara,venta-r,Edificio,https://www.inmuebles24.com/edificio-en-venta-en-guadalajara-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,San Pedro Tlaquepaque,venta-r,Edificio,https://www.inmuebles24.com/edificio-en-venta-en-san-pedro-tlaquepaque-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,TonalÃ¡,venta-r,Edificio,https://www.inmuebles24.com/edificio-en-venta-en-tonala-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapotlanejo,venta-r,Edificio,https://www.inmuebles24.com/edificio-en-venta-en-zapotlanejo-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,JuanacatlÃ¡n,venta-r,Edificio,https://www.inmuebles24.com/edificio-en-venta-en-juanacatlan-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,IxtlahuacÃ¡n de los Membrillos,venta-r,Edificio,https://www.inmuebles24.com/edificio-en-venta-en-ixtlahuacan-de-los-membrillos-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,El Salto,venta-r,Edificio,https://www.inmuebles24.com/edificio-en-venta-en-el-salto-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Tlajomulco de ZuÃ±iga,venta-r,Edificio,https://www.inmuebles24.com/edificio-en-venta-en-tlajomulco-de-zuniga-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapopan,venta-r,Huerta,https://www.inmuebles24.com/huerta-en-venta-en-zapopan-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Guadalajara,venta-r,Huerta,https://www.inmuebles24.com/huerta-en-venta-en-guadalajara-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,San Pedro Tlaquepaque,venta-r,Huerta,https://www.inmuebles24.com/huerta-en-venta-en-san-pedro-tlaquepaque-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,TonalÃ¡,venta-r,Huerta,https://www.inmuebles24.com/huerta-en-venta-en-tonala-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapotlanejo,venta-r,Huerta,https://www.inmuebles24.com/huerta-en-venta-en-zapotlanejo-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,JuanacatlÃ¡n,venta-r,Huerta,https://www.inmuebles24.com/huerta-en-venta-en-juanacatlan-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,IxtlahuacÃ¡n de los Membrillos,venta-r,Huerta,https://www.inmuebles24.com/huerta-en-venta-en-ixtlahuacan-de-los-membrillos-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,El Salto,venta-r,Huerta,https://www.inmuebles24.com/huerta-en-venta-en-el-salto-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Tlajomulco de ZuÃ±iga,venta-r,Huerta,https://www.inmuebles24.com/huerta-en-venta-en-tlajomulco-de-zuniga-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapopan,venta-r,Inmueble productivo urbano,https://www.inmuebles24.com/inmueble-productivo-urbano-en-venta-en-zapopan-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Guadalajara,venta-r,Inmueble productivo urbano,https://www.inmuebles24.com/inmueble-productivo-urbano-en-venta-en-guadalajara-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,San Pedro Tlaquepaque,venta-r,Inmueble productivo urbano,https://www.inmuebles24.com/inmueble-productivo-urbano-en-venta-en-san-pedro-tlaquepaque-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,TonalÃ¡,venta-r,Inmueble productivo urbano,https://www.inmuebles24.com/inmueble-productivo-urbano-en-venta-en-tonala-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapotlanejo,venta-r,Inmueble productivo urbano,https://www.inmuebles24.com/inmueble-productivo-urbano-en-venta-en-zapotlanejo-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,JuanacatlÃ¡n,venta-r,Inmueble productivo urbano,https://www.inmuebles24.com/inmueble-productivo-urbano-en-venta-en-juanacatlan-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,IxtlahuacÃ¡n de los Membrillos,venta-r,Inmueble productivo urbano,https://www.inmuebles24.com/inmueble-productivo-urbano-en-venta-en-ixtlahuacan-de-los-membrillos-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,El Salto,venta-r,Inmueble productivo urbano,https://www.inmuebles24.com/inmueble-productivo-urbano-en-venta-en-el-salto-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Tlajomulco de ZuÃ±iga,venta-r,Inmueble productivo urbano,https://www.inmuebles24.com/inmueble-productivo-urbano-en-venta-en-tlajomulco-de-zuniga-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapopan,venta-r,Local en centro comercial,https://www.inmuebles24.com/local-en-centro-comercial-en-venta-en-zapopan-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Guadalajara,venta-r,Local en centro comercial,https://www.inmuebles24.com/local-en-centro-comercial-en-venta-en-guadalajara-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,San Pedro Tlaquepaque,venta-r,Local en centro comercial,https://www.inmuebles24.com/local-en-centro-comercial-en-venta-en-san-pedro-tlaquepaque-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,TonalÃ¡,venta-r,Local en centro comercial,https://www.inmuebles24.com/local-en-centro-comercial-en-venta-en-tonala-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapotlanejo,venta-r,Local en centro comercial,https://www.inmuebles24.com/local-en-centro-comercial-en-venta-en-zapotlanejo-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,JuanacatlÃ¡n,venta-r,Local en centro comercial,https://www.inmuebles24.com/local-en-centro-comercial-en-venta-en-juanacatlan-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,IxtlahuacÃ¡n de los Membrillos,venta-r,Local en centro comercial,https://www.inmuebles24.com/local-en-centro-comercial-en-venta-en-ixtlahuacan-de-los-membrillos-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,El Salto,venta-r,Local en centro comercial,https://www.inmuebles24.com/local-en-centro-comercial-en-venta-en-el-salto-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Tlajomulco de ZuÃ±iga,venta-r,Local en centro comercial,https://www.inmuebles24.com/local-en-centro-comercial-en-venta-en-tlajomulco-de-zuniga-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapopan,venta-r,Locales comerciales,https://www.inmuebles24.com/locales-comerciales-en-venta-en-zapopan-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Guadalajara,venta-r,Locales comerciales,https://www.inmuebles24.com/locales-comerciales-en-venta-en-guadalajara-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,San Pedro Tlaquepaque,venta-r,Locales comerciales,https://www.inmuebles24.com/locales-comerciales-en-venta-en-san-pedro-tlaquepaque-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,TonalÃ¡,venta-r,Locales comerciales,https://www.inmuebles24.com/locales-comerciales-en-venta-en-tonala-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapotlanejo,venta-r,Locales comerciales,https://www.inmuebles24.com/locales-comerciales-en-venta-en-zapotlanejo-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,JuanacatlÃ¡n,venta-r,Locales comerciales,https://www.inmuebles24.com/locales-comerciales-en-venta-en-juanacatlan-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,IxtlahuacÃ¡n de los Membrillos,venta-r,Locales comerciales,https://www.inmuebles24.com/locales-comerciales-en-venta-en-ixtlahuacan-de-los-membrillos-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,El Salto,venta-r,Locales comerciales,https://www.inmuebles24.com/locales-comerciales-en-venta-en-el-salto-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Tlajomulco de ZuÃ±iga,venta-r,Locales comerciales,https://www.inmuebles24.com/locales-comerciales-en-venta-en-tlajomulco-de-zuniga-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapopan,venta-r,Nave industrial,https://www.inmuebles24.com/nave-industrial-en-venta-en-zapopan-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Guadalajara,venta-r,Nave industrial,https://www.inmuebles24.com/nave-industrial-en-venta-en-guadalajara-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,San Pedro Tlaquepaque,venta-r,Nave industrial,https://www.inmuebles24.com/nave-industrial-en-venta-en-san-pedro-tlaquepaque-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,TonalÃ¡,venta-r,Nave industrial,https://www.inmuebles24.com/nave-industrial-en-venta-en-tonala-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapotlanejo,venta-r,Nave industrial,https://www.inmuebles24.com/nave-industrial-en-venta-en-zapotlanejo-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,JuanacatlÃ¡n,venta-r,Nave industrial,https://www.inmuebles24.com/nave-industrial-en-venta-en-juanacatlan-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,IxtlahuacÃ¡n de los Membrillos,venta-r,Nave industrial,https://www.inmuebles24.com/nave-industrial-en-venta-en-ixtlahuacan-de-los-membrillos-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,El Salto,venta-r,Nave industrial,https://www.inmuebles24.com/nave-industrial-en-venta-en-el-salto-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Tlajomulco de ZuÃ±iga,venta-r,Nave industrial,https://www.inmuebles24.com/nave-industrial-en-venta-en-tlajomulco-de-zuniga-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapopan,venta-r,Oficinas,https://www.inmuebles24.com/oficinas-en-venta-en-zapopan-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Guadalajara,venta-r,Oficinas,https://www.inmuebles24.com/oficinas-en-venta-en-guadalajara-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,San Pedro Tlaquepaque,venta-r,Oficinas,https://www.inmuebles24.com/oficinas-en-venta-en-san-pedro-tlaquepaque-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,TonalÃ¡,venta-r,Oficinas,https://www.inmuebles24.com/oficinas-en-venta-en-tonala-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapotlanejo,venta-r,Oficinas,https://www.inmuebles24.com/oficinas-en-venta-en-zapotlanejo-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,JuanacatlÃ¡n,venta-r,Oficinas,https://www.inmuebles24.com/oficinas-en-venta-en-juanacatlan-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,IxtlahuacÃ¡n de los Membrillos,venta-r,Oficinas,https://www.inmuebles24.com/oficinas-en-venta-en-ixtlahuacan-de-los-membrillos-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,El Salto,venta-r,Oficinas,https://www.inmuebles24.com/oficinas-en-venta-en-el-salto-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Tlajomulco de ZuÃ±iga,venta-r,Oficinas,https://www.inmuebles24.com/oficinas-en-venta-en-tlajomulco-de-zuniga-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapopan,venta-r,Quinta,https://www.inmuebles24.com/quinta-en-venta-en-zapopan-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Guadalajara,venta-r,Quinta,https://www.inmuebles24.com/quinta-en-venta-en-guadalajara-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,San Pedro Tlaquepaque,venta-r,Quinta,https://www.inmuebles24.com/quinta-en-venta-en-san-pedro-tlaquepaque-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,TonalÃ¡,venta-r,Quinta,https://www.inmuebles24.com/quinta-en-venta-en-tonala-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapotlanejo,venta-r,Quinta,https://www.inmuebles24.com/quinta-en-venta-en-zapotlanejo-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,JuanacatlÃ¡n,venta-r,Quinta,https://www.inmuebles24.com/quinta-en-venta-en-juanacatlan-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,IxtlahuacÃ¡n de los Membrillos,venta-r,Quinta,https://www.inmuebles24.com/quinta-en-venta-en-ixtlahuacan-de-los-membrillos-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,El Salto,venta-r,Quinta,https://www.inmuebles24.com/quinta-en-venta-en-el-salto-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Tlajomulco de ZuÃ±iga,venta-r,Quinta,https://www.inmuebles24.com/quinta-en-venta-en-tlajomulco-de-zuniga-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapopan,venta-r,Terreno comercial,https://www.inmuebles24.com/terreno-comercial-en-venta-en-zapopan-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Guadalajara,venta-r,Terreno comercial,https://www.inmuebles24.com/terreno-comercial-en-venta-en-guadalajara-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,San Pedro Tlaquepaque,venta-r,Terreno comercial,https://www.inmuebles24.com/terreno-comercial-en-venta-en-san-pedro-tlaquepaque-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,TonalÃ¡,venta-r,Terreno comercial,https://www.inmuebles24.com/terreno-comercial-en-venta-en-tonala-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapotlanejo,venta-r,Terreno comercial,https://www.inmuebles24.com/terreno-comercial-en-venta-en-zapotlanejo-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,JuanacatlÃ¡n,venta-r,Terreno comercial,https://www.inmuebles24.com/terreno-comercial-en-venta-en-juanacatlan-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,IxtlahuacÃ¡n de los Membrillos,venta-r,Terreno comercial,https://www.inmuebles24.com/terreno-comercial-en-venta-en-ixtlahuacan-de-los-membrillos-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,El Salto,venta-r,Terreno comercial,https://www.inmuebles24.com/terreno-comercial-en-venta-en-el-salto-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Tlajomulco de ZuÃ±iga,venta-r,Terreno comercial,https://www.inmuebles24.com/terreno-comercial-en-venta-en-tlajomulco-de-zuniga-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapopan,venta-r,Terreno industrial,https://www.inmuebles24.com/terreno-industrial-en-venta-en-zapopan-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Guadalajara,venta-r,Terreno industrial,https://www.inmuebles24.com/terreno-industrial-en-venta-en-guadalajara-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,San Pedro Tlaquepaque,venta-r,Terreno industrial,https://www.inmuebles24.com/terreno-industrial-en-venta-en-san-pedro-tlaquepaque-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,TonalÃ¡,venta-r,Terreno industrial,https://www.inmuebles24.com/terreno-industrial-en-venta-en-tonala-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapotlanejo,venta-r,Terreno industrial,https://www.inmuebles24.com/terreno-industrial-en-venta-en-zapotlanejo-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,JuanacatlÃ¡n,venta-r,Terreno industrial,https://www.inmuebles24.com/terreno-industrial-en-venta-en-juanacatlan-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,IxtlahuacÃ¡n de los Membrillos,venta-r,Terreno industrial,https://www.inmuebles24.com/terreno-industrial-en-venta-en-ixtlahuacan-de-los-membrillos-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,El Salto,venta-r,Terreno industrial,https://www.inmuebles24.com/terreno-industrial-en-venta-en-el-salto-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Tlajomulco de ZuÃ±iga,venta-r,Terreno industrial,https://www.inmuebles24.com/terreno-industrial-en-venta-en-tlajomulco-de-zuniga-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapopan,venta-r,Terrenos,https://www.inmuebles24.com/terrenos-en-venta-en-zapopan-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Guadalajara,venta-r,Terrenos,https://www.inmuebles24.com/terrenos-en-venta-en-guadalajara-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,San Pedro Tlaquepaque,venta-r,Terrenos,https://www.inmuebles24.com/terrenos-en-venta-en-san-pedro-tlaquepaque-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,TonalÃ¡,venta-r,Terrenos,https://www.inmuebles24.com/terrenos-en-venta-en-tonala-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapotlanejo,venta-r,Terrenos,https://www.inmuebles24.com/terrenos-en-venta-en-zapotlanejo-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,JuanacatlÃ¡n,venta-r,Terrenos,https://www.inmuebles24.com/terrenos-en-venta-en-juanacatlan-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,IxtlahuacÃ¡n de los Membrillos,venta-r,Terrenos,https://www.inmuebles24.com/terrenos-en-venta-en-ixtlahuacan-de-los-membrillos-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,El Salto,venta-r,Terrenos,https://www.inmuebles24.com/terrenos-en-venta-en-el-salto-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Tlajomulco de ZuÃ±iga,venta-r,Terrenos,https://www.inmuebles24.com/terrenos-en-venta-en-tlajomulco-de-zuniga-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapopan,venta-r,Villa,https://www.inmuebles24.com/villa-en-venta-en-zapopan-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Guadalajara,venta-r,Villa,https://www.inmuebles24.com/villa-en-venta-en-guadalajara-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,San Pedro Tlaquepaque,venta-r,Villa,https://www.inmuebles24.com/villa-en-venta-en-san-pedro-tlaquepaque-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,TonalÃ¡,venta-r,Villa,https://www.inmuebles24.com/villa-en-venta-en-tonala-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapotlanejo,venta-r,Villa,https://www.inmuebles24.com/villa-en-venta-en-zapotlanejo-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,JuanacatlÃ¡n,venta-r,Villa,https://www.inmuebles24.com/villa-en-venta-en-juanacatlan-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,IxtlahuacÃ¡n de los Membrillos,venta-r,Villa,https://www.inmuebles24.com/villa-en-venta-en-ixtlahuacan-de-los-membrillos-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,El Salto,venta-r,Villa,https://www.inmuebles24.com/villa-en-venta-en-el-salto-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Tlajomulco de ZuÃ±iga,venta-r,Villa,https://www.inmuebles24.com/villa-en-venta-en-tlajomulco-de-zuniga-q-remate.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapopan,renta,Bodegas comerciales,https://www.inmuebles24.com/bodegas-comerciales-en-renta-en-zapopan.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Guadalajara,renta,Bodegas comerciales,https://www.inmuebles24.com/bodegas-comerciales-en-renta-en-guadalajara.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,San Pedro Tlaquepaque,renta,Bodegas comerciales,https://www.inmuebles24.com/bodegas-comerciales-en-renta-en-san-pedro-tlaquepaque.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,TonalÃ¡,renta,Bodegas comerciales,https://www.inmuebles24.com/bodegas-comerciales-en-renta-en-tonala.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapotlanejo,renta,Bodegas comerciales,https://www.inmuebles24.com/bodegas-comerciales-en-renta-en-zapotlanejo.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,JuanacatlÃ¡n,renta,Bodegas comerciales,https://www.inmuebles24.com/bodegas-comerciales-en-renta-en-juanacatlan.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,IxtlahuacÃ¡n de los Membrillos,renta,Bodegas comerciales,https://www.inmuebles24.com/bodegas-comerciales-en-renta-en-ixtlahuacan-de-los-membrillos.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,El Salto,renta,Bodegas comerciales,https://www.inmuebles24.com/bodegas-comerciales-en-renta-en-el-salto.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Tlajomulco de ZuÃ±iga,renta,Bodegas comerciales,https://www.inmuebles24.com/bodegas-comerciales-en-renta-en-tlajomulco-de-zuniga.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapopan,renta,Casa en condominio,https://www.inmuebles24.com/casa-en-condominio-en-renta-en-zapopan.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Guadalajara,renta,Casa en condominio,https://www.inmuebles24.com/casa-en-condominio-en-renta-en-guadalajara.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,San Pedro Tlaquepaque,renta,Casa en condominio,https://www.inmuebles24.com/casa-en-condominio-en-renta-en-san-pedro-tlaquepaque.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,TonalÃ¡,renta,Casa en condominio,https://www.inmuebles24.com/casa-en-condominio-en-renta-en-tonala.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapotlanejo,renta,Casa en condominio,https://www.inmuebles24.com/casa-en-condominio-en-renta-en-zapotlanejo.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,JuanacatlÃ¡n,renta,Casa en condominio,https://www.inmuebles24.com/casa-en-condominio-en-renta-en-juanacatlan.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,IxtlahuacÃ¡n de los Membrillos,renta,Casa en condominio,https://www.inmuebles24.com/casa-en-condominio-en-renta-en-ixtlahuacan-de-los-membrillos.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,El Salto,renta,Casa en condominio,https://www.inmuebles24.com/casa-en-condominio-en-renta-en-el-salto.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Tlajomulco de ZuÃ±iga,renta,Casa en condominio,https://www.inmuebles24.com/casa-en-condominio-en-renta-en-tlajomulco-de-zuniga.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapopan,renta,Casa uso de suelo,https://www.inmuebles24.com/casa-uso-de-suelo-en-renta-en-zapopan.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Guadalajara,renta,Casa uso de suelo,https://www.inmuebles24.com/casa-uso-de-suelo-en-renta-en-guadalajara.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,San Pedro Tlaquepaque,renta,Casa uso de suelo,https://www.inmuebles24.com/casa-uso-de-suelo-en-renta-en-san-pedro-tlaquepaque.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,TonalÃ¡,renta,Casa uso de suelo,https://www.inmuebles24.com/casa-uso-de-suelo-en-renta-en-tonala.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapotlanejo,renta,Casa uso de suelo,https://www.inmuebles24.com/casa-uso-de-suelo-en-renta-en-zapotlanejo.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,JuanacatlÃ¡n,renta,Casa uso de suelo,https://www.inmuebles24.com/casa-uso-de-suelo-en-renta-en-juanacatlan.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,IxtlahuacÃ¡n de los Membrillos,renta,Casa uso de suelo,https://www.inmuebles24.com/casa-uso-de-suelo-en-renta-en-ixtlahuacan-de-los-membrillos.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,El Salto,renta,Casa uso de suelo,https://www.inmuebles24.com/casa-uso-de-suelo-en-renta-en-el-salto.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Tlajomulco de ZuÃ±iga,renta,Casa uso de suelo,https://www.inmuebles24.com/casa-uso-de-suelo-en-renta-en-tlajomulco-de-zuniga.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapopan,renta,Casas,https://www.inmuebles24.com/casas-en-renta-en-zapopan.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Guadalajara,renta,Casas,https://www.inmuebles24.com/casas-en-renta-en-guadalajara.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,San Pedro Tlaquepaque,renta,Casas,https://www.inmuebles24.com/casas-en-renta-en-san-pedro-tlaquepaque.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,TonalÃ¡,renta,Casas,https://www.inmuebles24.com/casas-en-renta-en-tonala.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapotlanejo,renta,Casas,https://www.inmuebles24.com/casas-en-renta-en-zapotlanejo.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,JuanacatlÃ¡n,renta,Casas,https://www.inmuebles24.com/casas-en-renta-en-juanacatlan.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,IxtlahuacÃ¡n de los Membrillos,renta,Casas,https://www.inmuebles24.com/casas-en-renta-en-ixtlahuacan-de-los-membrillos.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,El Salto,renta,Casas,https://www.inmuebles24.com/casas-en-renta-en-el-salto.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Tlajomulco de ZuÃ±iga,renta,Casas,https://www.inmuebles24.com/casas-en-renta-en-tlajomulco-de-zuniga.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapopan,renta,DÃºplex,https://www.inmuebles24.com/duplex-en-renta-en-zapopan.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Guadalajara,renta,DÃºplex,https://www.inmuebles24.com/duplex-en-renta-en-guadalajara.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,San Pedro Tlaquepaque,renta,DÃºplex,https://www.inmuebles24.com/duplex-en-renta-en-san-pedro-tlaquepaque.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,TonalÃ¡,renta,DÃºplex,https://www.inmuebles24.com/duplex-en-renta-en-tonala.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapotlanejo,renta,DÃºplex,https://www.inmuebles24.com/duplex-en-renta-en-zapotlanejo.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,JuanacatlÃ¡n,renta,DÃºplex,https://www.inmuebles24.com/duplex-en-renta-en-juanacatlan.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,IxtlahuacÃ¡n de los Membrillos,renta,DÃºplex,https://www.inmuebles24.com/duplex-en-renta-en-ixtlahuacan-de-los-membrillos.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,El Salto,renta,DÃºplex,https://www.inmuebles24.com/duplex-en-renta-en-el-salto.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Tlajomulco de ZuÃ±iga,renta,DÃºplex,https://www.inmuebles24.com/duplex-en-renta-en-tlajomulco-de-zuniga.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapopan,renta,Departamento compartido,https://www.inmuebles24.com/departamento-compartido-en-renta-en-zapopan.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Guadalajara,renta,Departamento compartido,https://www.inmuebles24.com/departamento-compartido-en-renta-en-guadalajara.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,San Pedro Tlaquepaque,renta,Departamento compartido,https://www.inmuebles24.com/departamento-compartido-en-renta-en-san-pedro-tlaquepaque.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,TonalÃ¡,renta,Departamento compartido,https://www.inmuebles24.com/departamento-compartido-en-renta-en-tonala.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapotlanejo,renta,Departamento compartido,https://www.inmuebles24.com/departamento-compartido-en-renta-en-zapotlanejo.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,JuanacatlÃ¡n,renta,Departamento compartido,https://www.inmuebles24.com/departamento-compartido-en-renta-en-juanacatlan.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,IxtlahuacÃ¡n de los Membrillos,renta,Departamento compartido,https://www.inmuebles24.com/departamento-compartido-en-renta-en-ixtlahuacan-de-los-membrillos.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,El Salto,renta,Departamento compartido,https://www.inmuebles24.com/departamento-compartido-en-renta-en-el-salto.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Tlajomulco de ZuÃ±iga,renta,Departamento compartido,https://www.inmuebles24.com/departamento-compartido-en-renta-en-tlajomulco-de-zuniga.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapopan,renta,Departamentos,https://www.inmuebles24.com/departamentos-en-renta-en-zapopan.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Guadalajara,renta,Departamentos,https://www.inmuebles24.com/departamentos-en-renta-en-guadalajara.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,San Pedro Tlaquepaque,renta,Departamentos,https://www.inmuebles24.com/departamentos-en-renta-en-san-pedro-tlaquepaque.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,TonalÃ¡,renta,Departamentos,https://www.inmuebles24.com/departamentos-en-renta-en-tonala.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapotlanejo,renta,Departamentos,https://www.inmuebles24.com/departamentos-en-renta-en-zapotlanejo.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,JuanacatlÃ¡n,renta,Departamentos,https://www.inmuebles24.com/departamentos-en-renta-en-juanacatlan.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,IxtlahuacÃ¡n de los Membrillos,renta,Departamentos,https://www.inmuebles24.com/departamentos-en-renta-en-ixtlahuacan-de-los-membrillos.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,El Salto,renta,Departamentos,https://www.inmuebles24.com/departamentos-en-renta-en-el-salto.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Tlajomulco de ZuÃ±iga,renta,Departamentos,https://www.inmuebles24.com/departamentos-en-renta-en-tlajomulco-de-zuniga.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapopan,venta-d,Desarrollo horizontal,https://www.inmuebles24.com/desarrollo-horizontal-en-renta-en-zapopan.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Guadalajara,venta-d,Desarrollo horizontal,https://www.inmuebles24.com/desarrollo-horizontal-en-renta-en-guadalajara.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,San Pedro Tlaquepaque,venta-d,Desarrollo horizontal,https://www.inmuebles24.com/desarrollo-horizontal-en-renta-en-san-pedro-tlaquepaque.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,TonalÃ¡,venta-d,Desarrollo horizontal,https://www.inmuebles24.com/desarrollo-horizontal-en-renta-en-tonala.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapotlanejo,venta-d,Desarrollo horizontal,https://www.inmuebles24.com/desarrollo-horizontal-en-renta-en-zapotlanejo.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,JuanacatlÃ¡n,venta-d,Desarrollo horizontal,https://www.inmuebles24.com/desarrollo-horizontal-en-renta-en-juanacatlan.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,IxtlahuacÃ¡n de los Membrillos,venta-d,Desarrollo horizontal,https://www.inmuebles24.com/desarrollo-horizontal-en-renta-en-ixtlahuacan-de-los-membrillos.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,El Salto,venta-d,Desarrollo horizontal,https://www.inmuebles24.com/desarrollo-horizontal-en-renta-en-el-salto.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Tlajomulco de ZuÃ±iga,venta-d,Desarrollo horizontal,https://www.inmuebles24.com/desarrollo-horizontal-en-renta-en-tlajomulco-de-zuniga.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapopan,venta-d,Desarrollo horizontal/vertical,https://www.inmuebles24.com/desarrollo-horizontal-vertical-en-renta-en-zapopan.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Guadalajara,venta-d,Desarrollo horizontal/vertical,https://www.inmuebles24.com/desarrollo-horizontal-vertical-en-renta-en-guadalajara.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,San Pedro Tlaquepaque,venta-d,Desarrollo horizontal/vertical,https://www.inmuebles24.com/desarrollo-horizontal-vertical-en-renta-en-san-pedro-tlaquepaque.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,TonalÃ¡,venta-d,Desarrollo horizontal/vertical,https://www.inmuebles24.com/desarrollo-horizontal-vertical-en-renta-en-tonala.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapotlanejo,venta-d,Desarrollo horizontal/vertical,https://www.inmuebles24.com/desarrollo-horizontal-vertical-en-renta-en-zapotlanejo.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,JuanacatlÃ¡n,venta-d,Desarrollo horizontal/vertical,https://www.inmuebles24.com/desarrollo-horizontal-vertical-en-renta-en-juanacatlan.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,IxtlahuacÃ¡n de los Membrillos,venta-d,Desarrollo horizontal/vertical,https://www.inmuebles24.com/desarrollo-horizontal-vertical-en-renta-en-ixtlahuacan-de-los-membrillos.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,El Salto,venta-d,Desarrollo horizontal/vertical,https://www.inmuebles24.com/desarrollo-horizontal-vertical-en-renta-en-el-salto.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Tlajomulco de ZuÃ±iga,venta-d,Desarrollo horizontal/vertical,https://www.inmuebles24.com/desarrollo-horizontal-vertical-en-renta-en-tlajomulco-de-zuniga.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapopan,renta,Desarrollo vertical,https://www.inmuebles24.com/desarrollo-vertical-en-renta-en-zapopan.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Guadalajara,renta,Desarrollo vertical,https://www.inmuebles24.com/desarrollo-vertical-en-renta-en-guadalajara.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,San Pedro Tlaquepaque,renta,Desarrollo vertical,https://www.inmuebles24.com/desarrollo-vertical-en-renta-en-san-pedro-tlaquepaque.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,TonalÃ¡,renta,Desarrollo vertical,https://www.inmuebles24.com/desarrollo-vertical-en-renta-en-tonala.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapotlanejo,renta,Desarrollo vertical,https://www.inmuebles24.com/desarrollo-vertical-en-renta-en-zapotlanejo.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,JuanacatlÃ¡n,renta,Desarrollo vertical,https://www.inmuebles24.com/desarrollo-vertical-en-renta-en-juanacatlan.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,IxtlahuacÃ¡n de los Membrillos,renta,Desarrollo vertical,https://www.inmuebles24.com/desarrollo-vertical-en-renta-en-ixtlahuacan-de-los-membrillos.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,El Salto,renta,Desarrollo vertical,https://www.inmuebles24.com/desarrollo-vertical-en-renta-en-el-salto.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Tlajomulco de ZuÃ±iga,renta,Desarrollo vertical,https://www.inmuebles24.com/desarrollo-vertical-en-renta-en-tlajomulco-de-zuniga.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapopan,renta,Edificio,https://www.inmuebles24.com/edificio-en-renta-en-zapopan.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Guadalajara,renta,Edificio,https://www.inmuebles24.com/edificio-en-renta-en-guadalajara.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,San Pedro Tlaquepaque,renta,Edificio,https://www.inmuebles24.com/edificio-en-renta-en-san-pedro-tlaquepaque.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,TonalÃ¡,renta,Edificio,https://www.inmuebles24.com/edificio-en-renta-en-tonala.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapotlanejo,renta,Edificio,https://www.inmuebles24.com/edificio-en-renta-en-zapotlanejo.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,JuanacatlÃ¡n,renta,Edificio,https://www.inmuebles24.com/edificio-en-renta-en-juanacatlan.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,IxtlahuacÃ¡n de los Membrillos,renta,Edificio,https://www.inmuebles24.com/edificio-en-renta-en-ixtlahuacan-de-los-membrillos.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,El Salto,renta,Edificio,https://www.inmuebles24.com/edificio-en-renta-en-el-salto.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Tlajomulco de ZuÃ±iga,renta,Edificio,https://www.inmuebles24.com/edificio-en-renta-en-tlajomulco-de-zuniga.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapopan,renta,Huerta,https://www.inmuebles24.com/huerta-en-renta-en-zapopan.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Guadalajara,renta,Huerta,https://www.inmuebles24.com/huerta-en-renta-en-guadalajara.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,San Pedro Tlaquepaque,renta,Huerta,https://www.inmuebles24.com/huerta-en-renta-en-san-pedro-tlaquepaque.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,TonalÃ¡,renta,Huerta,https://www.inmuebles24.com/huerta-en-renta-en-tonala.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapotlanejo,renta,Huerta,https://www.inmuebles24.com/huerta-en-renta-en-zapotlanejo.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,JuanacatlÃ¡n,renta,Huerta,https://www.inmuebles24.com/huerta-en-renta-en-juanacatlan.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,IxtlahuacÃ¡n de los Membrillos,renta,Huerta,https://www.inmuebles24.com/huerta-en-renta-en-ixtlahuacan-de-los-membrillos.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,El Salto,renta,Huerta,https://www.inmuebles24.com/huerta-en-renta-en-el-salto.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Tlajomulco de ZuÃ±iga,renta,Huerta,https://www.inmuebles24.com/huerta-en-renta-en-tlajomulco-de-zuniga.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapopan,renta,Inmueble productivo urbano,https://www.inmuebles24.com/inmueble-productivo-urbano-en-renta-en-zapopan.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Guadalajara,renta,Inmueble productivo urbano,https://www.inmuebles24.com/inmueble-productivo-urbano-en-renta-en-guadalajara.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,San Pedro Tlaquepaque,renta,Inmueble productivo urbano,https://www.inmuebles24.com/inmueble-productivo-urbano-en-renta-en-san-pedro-tlaquepaque.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,TonalÃ¡,renta,Inmueble productivo urbano,https://www.inmuebles24.com/inmueble-productivo-urbano-en-renta-en-tonala.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapotlanejo,renta,Inmueble productivo urbano,https://www.inmuebles24.com/inmueble-productivo-urbano-en-renta-en-zapotlanejo.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,JuanacatlÃ¡n,renta,Inmueble productivo urbano,https://www.inmuebles24.com/inmueble-productivo-urbano-en-renta-en-juanacatlan.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,IxtlahuacÃ¡n de los Membrillos,renta,Inmueble productivo urbano,https://www.inmuebles24.com/inmueble-productivo-urbano-en-renta-en-ixtlahuacan-de-los-membrillos.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,El Salto,renta,Inmueble productivo urbano,https://www.inmuebles24.com/inmueble-productivo-urbano-en-renta-en-el-salto.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Tlajomulco de ZuÃ±iga,renta,Inmueble productivo urbano,https://www.inmuebles24.com/inmueble-productivo-urbano-en-renta-en-tlajomulco-de-zuniga.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapopan,renta,Local en centro comercial,https://www.inmuebles24.com/local-en-centro-comercial-en-renta-en-zapopan.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Guadalajara,renta,Local en centro comercial,https://www.inmuebles24.com/local-en-centro-comercial-en-renta-en-guadalajara.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,San Pedro Tlaquepaque,renta,Local en centro comercial,https://www.inmuebles24.com/local-en-centro-comercial-en-renta-en-san-pedro-tlaquepaque.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,TonalÃ¡,renta,Local en centro comercial,https://www.inmuebles24.com/local-en-centro-comercial-en-renta-en-tonala.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapotlanejo,renta,Local en centro comercial,https://www.inmuebles24.com/local-en-centro-comercial-en-renta-en-zapotlanejo.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,JuanacatlÃ¡n,renta,Local en centro comercial,https://www.inmuebles24.com/local-en-centro-comercial-en-renta-en-juanacatlan.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,IxtlahuacÃ¡n de los Membrillos,renta,Local en centro comercial,https://www.inmuebles24.com/local-en-centro-comercial-en-renta-en-ixtlahuacan-de-los-membrillos.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,El Salto,renta,Local en centro comercial,https://www.inmuebles24.com/local-en-centro-comercial-en-renta-en-el-salto.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Tlajomulco de ZuÃ±iga,renta,Local en centro comercial,https://www.inmuebles24.com/local-en-centro-comercial-en-renta-en-tlajomulco-de-zuniga.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapopan,renta,Locales comerciales,https://www.inmuebles24.com/locales-comerciales-en-renta-en-zapopan.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Guadalajara,renta,Locales comerciales,https://www.inmuebles24.com/locales-comerciales-en-renta-en-guadalajara.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,San Pedro Tlaquepaque,renta,Locales comerciales,https://www.inmuebles24.com/locales-comerciales-en-renta-en-san-pedro-tlaquepaque.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,TonalÃ¡,renta,Locales comerciales,https://www.inmuebles24.com/locales-comerciales-en-renta-en-tonala.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapotlanejo,renta,Locales comerciales,https://www.inmuebles24.com/locales-comerciales-en-renta-en-zapotlanejo.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,JuanacatlÃ¡n,renta,Locales comerciales,https://www.inmuebles24.com/locales-comerciales-en-renta-en-juanacatlan.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,IxtlahuacÃ¡n de los Membrillos,renta,Locales comerciales,https://www.inmuebles24.com/locales-comerciales-en-renta-en-ixtlahuacan-de-los-membrillos.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,El Salto,renta,Locales comerciales,https://www.inmuebles24.com/locales-comerciales-en-renta-en-el-salto.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Tlajomulco de ZuÃ±iga,renta,Locales comerciales,https://www.inmuebles24.com/locales-comerciales-en-renta-en-tlajomulco-de-zuniga.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapopan,renta,Nave industrial,https://www.inmuebles24.com/nave-industrial-en-renta-en-zapopan.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Guadalajara,renta,Nave industrial,https://www.inmuebles24.com/nave-industrial-en-renta-en-guadalajara.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,San Pedro Tlaquepaque,renta,Nave industrial,https://www.inmuebles24.com/nave-industrial-en-renta-en-san-pedro-tlaquepaque.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,TonalÃ¡,renta,Nave industrial,https://www.inmuebles24.com/nave-industrial-en-renta-en-tonala.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapotlanejo,renta,Nave industrial,https://www.inmuebles24.com/nave-industrial-en-renta-en-zapotlanejo.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,JuanacatlÃ¡n,renta,Nave industrial,https://www.inmuebles24.com/nave-industrial-en-renta-en-juanacatlan.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,IxtlahuacÃ¡n de los Membrillos,renta,Nave industrial,https://www.inmuebles24.com/nave-industrial-en-renta-en-ixtlahuacan-de-los-membrillos.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,El Salto,renta,Nave industrial,https://www.inmuebles24.com/nave-industrial-en-renta-en-el-salto.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Tlajomulco de ZuÃ±iga,renta,Nave industrial,https://www.inmuebles24.com/nave-industrial-en-renta-en-tlajomulco-de-zuniga.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapopan,renta,Oficinas,https://www.inmuebles24.com/oficinas-en-renta-en-zapopan.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Guadalajara,renta,Oficinas,https://www.inmuebles24.com/oficinas-en-renta-en-guadalajara.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,San Pedro Tlaquepaque,renta,Oficinas,https://www.inmuebles24.com/oficinas-en-renta-en-san-pedro-tlaquepaque.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,TonalÃ¡,renta,Oficinas,https://www.inmuebles24.com/oficinas-en-renta-en-tonala.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapotlanejo,renta,Oficinas,https://www.inmuebles24.com/oficinas-en-renta-en-zapotlanejo.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,JuanacatlÃ¡n,renta,Oficinas,https://www.inmuebles24.com/oficinas-en-renta-en-juanacatlan.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,IxtlahuacÃ¡n de los Membrillos,renta,Oficinas,https://www.inmuebles24.com/oficinas-en-renta-en-ixtlahuacan-de-los-membrillos.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,El Salto,renta,Oficinas,https://www.inmuebles24.com/oficinas-en-renta-en-el-salto.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Tlajomulco de ZuÃ±iga,renta,Oficinas,https://www.inmuebles24.com/oficinas-en-renta-en-tlajomulco-de-zuniga.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapopan,renta,Quinta,https://www.inmuebles24.com/quinta-en-renta-en-zapopan.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Guadalajara,renta,Quinta,https://www.inmuebles24.com/quinta-en-renta-en-guadalajara.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,San Pedro Tlaquepaque,renta,Quinta,https://www.inmuebles24.com/quinta-en-renta-en-san-pedro-tlaquepaque.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,TonalÃ¡,renta,Quinta,https://www.inmuebles24.com/quinta-en-renta-en-tonala.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapotlanejo,renta,Quinta,https://www.inmuebles24.com/quinta-en-renta-en-zapotlanejo.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,JuanacatlÃ¡n,renta,Quinta,https://www.inmuebles24.com/quinta-en-renta-en-juanacatlan.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,IxtlahuacÃ¡n de los Membrillos,renta,Quinta,https://www.inmuebles24.com/quinta-en-renta-en-ixtlahuacan-de-los-membrillos.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,El Salto,renta,Quinta,https://www.inmuebles24.com/quinta-en-renta-en-el-salto.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Tlajomulco de ZuÃ±iga,renta,Quinta,https://www.inmuebles24.com/quinta-en-renta-en-tlajomulco-de-zuniga.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapopan,renta,Terreno comercial,https://www.inmuebles24.com/terreno-comercial-en-renta-en-zapopan.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Guadalajara,renta,Terreno comercial,https://www.inmuebles24.com/terreno-comercial-en-renta-en-guadalajara.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,San Pedro Tlaquepaque,renta,Terreno comercial,https://www.inmuebles24.com/terreno-comercial-en-renta-en-san-pedro-tlaquepaque.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,TonalÃ¡,renta,Terreno comercial,https://www.inmuebles24.com/terreno-comercial-en-renta-en-tonala.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapotlanejo,renta,Terreno comercial,https://www.inmuebles24.com/terreno-comercial-en-renta-en-zapotlanejo.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,JuanacatlÃ¡n,renta,Terreno comercial,https://www.inmuebles24.com/terreno-comercial-en-renta-en-juanacatlan.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,IxtlahuacÃ¡n de los Membrillos,renta,Terreno comercial,https://www.inmuebles24.com/terreno-comercial-en-renta-en-ixtlahuacan-de-los-membrillos.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,El Salto,renta,Terreno comercial,https://www.inmuebles24.com/terreno-comercial-en-renta-en-el-salto.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Tlajomulco de ZuÃ±iga,renta,Terreno comercial,https://www.inmuebles24.com/terreno-comercial-en-renta-en-tlajomulco-de-zuniga.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapopan,renta,Terreno industrial,https://www.inmuebles24.com/terreno-industrial-en-renta-en-zapopan.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Guadalajara,renta,Terreno industrial,https://www.inmuebles24.com/terreno-industrial-en-renta-en-guadalajara.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,San Pedro Tlaquepaque,renta,Terreno industrial,https://www.inmuebles24.com/terreno-industrial-en-renta-en-san-pedro-tlaquepaque.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,TonalÃ¡,renta,Terreno industrial,https://www.inmuebles24.com/terreno-industrial-en-renta-en-tonala.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapotlanejo,renta,Terreno industrial,https://www.inmuebles24.com/terreno-industrial-en-renta-en-zapotlanejo.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,JuanacatlÃ¡n,renta,Terreno industrial,https://www.inmuebles24.com/terreno-industrial-en-renta-en-juanacatlan.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,IxtlahuacÃ¡n de los Membrillos,renta,Terreno industrial,https://www.inmuebles24.com/terreno-industrial-en-renta-en-ixtlahuacan-de-los-membrillos.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,El Salto,renta,Terreno industrial,https://www.inmuebles24.com/terreno-industrial-en-renta-en-el-salto.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Tlajomulco de ZuÃ±iga,renta,Terreno industrial,https://www.inmuebles24.com/terreno-industrial-en-renta-en-tlajomulco-de-zuniga.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapopan,renta,Terrenos,https://www.inmuebles24.com/terrenos-en-renta-en-zapopan.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Guadalajara,renta,Terrenos,https://www.inmuebles24.com/terrenos-en-renta-en-guadalajara.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,San Pedro Tlaquepaque,renta,Terrenos,https://www.inmuebles24.com/terrenos-en-renta-en-san-pedro-tlaquepaque.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,TonalÃ¡,renta,Terrenos,https://www.inmuebles24.com/terrenos-en-renta-en-tonala.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapotlanejo,renta,Terrenos,https://www.inmuebles24.com/terrenos-en-renta-en-zapotlanejo.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,JuanacatlÃ¡n,renta,Terrenos,https://www.inmuebles24.com/terrenos-en-renta-en-juanacatlan.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,IxtlahuacÃ¡n de los Membrillos,renta,Terrenos,https://www.inmuebles24.com/terrenos-en-renta-en-ixtlahuacan-de-los-membrillos.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,El Salto,renta,Terrenos,https://www.inmuebles24.com/terrenos-en-renta-en-el-salto.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Tlajomulco de ZuÃ±iga,renta,Terrenos,https://www.inmuebles24.com/terrenos-en-renta-en-tlajomulco-de-zuniga.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapopan,renta,Villa,https://www.inmuebles24.com/villa-en-renta-en-zapopan.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Guadalajara,renta,Villa,https://www.inmuebles24.com/villa-en-renta-en-guadalajara.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,San Pedro Tlaquepaque,renta,Villa,https://www.inmuebles24.com/villa-en-renta-en-san-pedro-tlaquepaque.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,TonalÃ¡,renta,Villa,https://www.inmuebles24.com/villa-en-renta-en-tonala.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Zapotlanejo,renta,Villa,https://www.inmuebles24.com/villa-en-renta-en-zapotlanejo.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,JuanacatlÃ¡n,renta,Villa,https://www.inmuebles24.com/villa-en-renta-en-juanacatlan.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,IxtlahuacÃ¡n de los Membrillos,renta,Villa,https://www.inmuebles24.com/villa-en-renta-en-ixtlahuacan-de-los-membrillos.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,El Salto,renta,Villa,https://www.inmuebles24.com/villa-en-renta-en-el-salto.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Inmuebles24,Tlajomulco de ZuÃ±iga,renta,Villa,https://www.inmuebles24.com/villa-en-renta-en-tlajomulco-de-zuniga.html,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+PaginaWeb,Ciudad,Operación,ProductoPaginaWeb,URL
+Inmuebles24,Zapopan,venta,Bodegas comerciales,https://www.inmuebles24.com/bodegas-comerciales-en-venta-en-zapopan.html
+Inmuebles24,Guadalajara,venta,Bodegas comerciales,https://www.inmuebles24.com/bodegas-comerciales-en-venta-en-guadalajara.html
+Inmuebles24,San Pedro Tlaquepaque,venta,Bodegas comerciales,https://www.inmuebles24.com/bodegas-comerciales-en-venta-en-san-pedro-tlaquepaque.html
+Inmuebles24,Tonalá,venta,Bodegas comerciales,https://www.inmuebles24.com/bodegas-comerciales-en-venta-en-tonala.html
+Inmuebles24,Zapotlanejo,venta,Bodegas comerciales,https://www.inmuebles24.com/bodegas-comerciales-en-venta-en-zapotlanejo.html
+Inmuebles24,Juanacatlán,venta,Bodegas comerciales,https://www.inmuebles24.com/bodegas-comerciales-en-venta-en-juanacatlan.html
+Inmuebles24,Ixtlahuacán de los Membrillos,venta,Bodegas comerciales,https://www.inmuebles24.com/bodegas-comerciales-en-venta-en-ixtlahuacan-de-los-membrillos.html
+Inmuebles24,El Salto,venta,Bodegas comerciales,https://www.inmuebles24.com/bodegas-comerciales-en-venta-en-el-salto.html
+Inmuebles24,Tlajomulco de Zuñiga,venta,Bodegas comerciales,https://www.inmuebles24.com/bodegas-comerciales-en-venta-en-tlajomulco-de-zuniga.html
+Inmuebles24,Zapopan,venta,Casa en condominio,https://www.inmuebles24.com/casa-en-condominio-en-venta-en-zapopan.html
+Inmuebles24,Guadalajara,venta,Casa en condominio,https://www.inmuebles24.com/casa-en-condominio-en-venta-en-guadalajara.html
+Inmuebles24,San Pedro Tlaquepaque,venta,Casa en condominio,https://www.inmuebles24.com/casa-en-condominio-en-venta-en-san-pedro-tlaquepaque.html
+Inmuebles24,Tonalá,venta,Casa en condominio,https://www.inmuebles24.com/casa-en-condominio-en-venta-en-tonala.html
+Inmuebles24,Zapotlanejo,venta,Casa en condominio,https://www.inmuebles24.com/casa-en-condominio-en-venta-en-zapotlanejo.html
+Inmuebles24,Juanacatlán,venta,Casa en condominio,https://www.inmuebles24.com/casa-en-condominio-en-venta-en-juanacatlan.html
+Inmuebles24,Ixtlahuacán de los Membrillos,venta,Casa en condominio,https://www.inmuebles24.com/casa-en-condominio-en-venta-en-ixtlahuacan-de-los-membrillos.html
+Inmuebles24,El Salto,venta,Casa en condominio,https://www.inmuebles24.com/casa-en-condominio-en-venta-en-el-salto.html
+Inmuebles24,Tlajomulco de Zuñiga,venta,Casa en condominio,https://www.inmuebles24.com/casa-en-condominio-en-venta-en-tlajomulco-de-zuniga.html
+Inmuebles24,Zapopan,venta,Casa uso de suelo,https://www.inmuebles24.com/casa-uso-de-suelo-en-venta-en-zapopan.html
+Inmuebles24,Guadalajara,venta,Casa uso de suelo,https://www.inmuebles24.com/casa-uso-de-suelo-en-venta-en-guadalajara.html
+Inmuebles24,San Pedro Tlaquepaque,venta,Casa uso de suelo,https://www.inmuebles24.com/casa-uso-de-suelo-en-venta-en-san-pedro-tlaquepaque.html
+Inmuebles24,Tonalá,venta,Casa uso de suelo,https://www.inmuebles24.com/casa-uso-de-suelo-en-venta-en-tonala.html
+Inmuebles24,Zapotlanejo,venta,Casa uso de suelo,https://www.inmuebles24.com/casa-uso-de-suelo-en-venta-en-zapotlanejo.html
+Inmuebles24,Juanacatlán,venta,Casa uso de suelo,https://www.inmuebles24.com/casa-uso-de-suelo-en-venta-en-juanacatlan.html
+Inmuebles24,Ixtlahuacán de los Membrillos,venta,Casa uso de suelo,https://www.inmuebles24.com/casa-uso-de-suelo-en-venta-en-ixtlahuacan-de-los-membrillos.html
+Inmuebles24,El Salto,venta,Casa uso de suelo,https://www.inmuebles24.com/casa-uso-de-suelo-en-venta-en-el-salto.html
+Inmuebles24,Tlajomulco de Zuñiga,venta,Casa uso de suelo,https://www.inmuebles24.com/casa-uso-de-suelo-en-venta-en-tlajomulco-de-zuniga.html
+Inmuebles24,Zapopan,venta,Casas,https://www.inmuebles24.com/casas-en-venta-en-zapopan.html
+Inmuebles24,Guadalajara,venta,Casas,https://www.inmuebles24.com/casas-en-venta-en-guadalajara.html
+Inmuebles24,San Pedro Tlaquepaque,venta,Casas,https://www.inmuebles24.com/casas-en-venta-en-san-pedro-tlaquepaque.html
+Inmuebles24,Tonalá,venta,Casas,https://www.inmuebles24.com/casas-en-venta-en-tonala.html
+Inmuebles24,Zapotlanejo,venta,Casas,https://www.inmuebles24.com/casas-en-venta-en-zapotlanejo.html
+Inmuebles24,Juanacatlán,venta,Casas,https://www.inmuebles24.com/casas-en-venta-en-juanacatlan.html
+Inmuebles24,Ixtlahuacán de los Membrillos,venta,Casas,https://www.inmuebles24.com/casas-en-venta-en-ixtlahuacan-de-los-membrillos.html
+Inmuebles24,El Salto,venta,Casas,https://www.inmuebles24.com/casas-en-venta-en-el-salto.html
+Inmuebles24,Tlajomulco de Zuñiga,venta,Casas,https://www.inmuebles24.com/casas-en-venta-en-tlajomulco-de-zuniga.html
+Inmuebles24,Zapopan,venta,Dúplex,https://www.inmuebles24.com/duplex-en-venta-en-zapopan.html
+Inmuebles24,Guadalajara,venta,Dúplex,https://www.inmuebles24.com/duplex-en-venta-en-guadalajara.html
+Inmuebles24,San Pedro Tlaquepaque,venta,Dúplex,https://www.inmuebles24.com/duplex-en-venta-en-san-pedro-tlaquepaque.html
+Inmuebles24,Tonalá,venta,Dúplex,https://www.inmuebles24.com/duplex-en-venta-en-tonala.html
+Inmuebles24,Zapotlanejo,venta,Dúplex,https://www.inmuebles24.com/duplex-en-venta-en-zapotlanejo.html
+Inmuebles24,Juanacatlán,venta,Dúplex,https://www.inmuebles24.com/duplex-en-venta-en-juanacatlan.html
+Inmuebles24,Ixtlahuacán de los Membrillos,venta,Dúplex,https://www.inmuebles24.com/duplex-en-venta-en-ixtlahuacan-de-los-membrillos.html
+Inmuebles24,El Salto,venta,Dúplex,https://www.inmuebles24.com/duplex-en-venta-en-el-salto.html
+Inmuebles24,Tlajomulco de Zuñiga,venta,Dúplex,https://www.inmuebles24.com/duplex-en-venta-en-tlajomulco-de-zuniga.html
+Inmuebles24,Zapopan,venta,Departamento compartido,https://www.inmuebles24.com/departamento-compartido-en-venta-en-zapopan.html
+Inmuebles24,Guadalajara,venta,Departamento compartido,https://www.inmuebles24.com/departamento-compartido-en-venta-en-guadalajara.html
+Inmuebles24,San Pedro Tlaquepaque,venta,Departamento compartido,https://www.inmuebles24.com/departamento-compartido-en-venta-en-san-pedro-tlaquepaque.html
+Inmuebles24,Tonalá,venta,Departamento compartido,https://www.inmuebles24.com/departamento-compartido-en-venta-en-tonala.html
+Inmuebles24,Zapotlanejo,venta,Departamento compartido,https://www.inmuebles24.com/departamento-compartido-en-venta-en-zapotlanejo.html
+Inmuebles24,Juanacatlán,venta,Departamento compartido,https://www.inmuebles24.com/departamento-compartido-en-venta-en-juanacatlan.html
+Inmuebles24,Ixtlahuacán de los Membrillos,venta,Departamento compartido,https://www.inmuebles24.com/departamento-compartido-en-venta-en-ixtlahuacan-de-los-membrillos.html
+Inmuebles24,El Salto,venta,Departamento compartido,https://www.inmuebles24.com/departamento-compartido-en-venta-en-el-salto.html
+Inmuebles24,Tlajomulco de Zuñiga,venta,Departamento compartido,https://www.inmuebles24.com/departamento-compartido-en-venta-en-tlajomulco-de-zuniga.html
+Inmuebles24,Zapopan,venta,Departamentos,https://www.inmuebles24.com/departamentos-en-venta-en-zapopan.html
+Inmuebles24,Guadalajara,venta,Departamentos,https://www.inmuebles24.com/departamentos-en-venta-en-guadalajara.html
+Inmuebles24,San Pedro Tlaquepaque,venta,Departamentos,https://www.inmuebles24.com/departamentos-en-venta-en-san-pedro-tlaquepaque.html
+Inmuebles24,Tonalá,venta,Departamentos,https://www.inmuebles24.com/departamentos-en-venta-en-tonala.html
+Inmuebles24,Zapotlanejo,venta,Departamentos,https://www.inmuebles24.com/departamentos-en-venta-en-zapotlanejo.html
+Inmuebles24,Juanacatlán,venta,Departamentos,https://www.inmuebles24.com/departamentos-en-venta-en-juanacatlan.html
+Inmuebles24,Ixtlahuacán de los Membrillos,venta,Departamentos,https://www.inmuebles24.com/departamentos-en-venta-en-ixtlahuacan-de-los-membrillos.html
+Inmuebles24,El Salto,venta,Departamentos,https://www.inmuebles24.com/departamentos-en-venta-en-el-salto.html
+Inmuebles24,Tlajomulco de Zuñiga,venta,Departamentos,https://www.inmuebles24.com/departamentos-en-venta-en-tlajomulco-de-zuniga.html
+Inmuebles24,Zapopan,venta-d,Desarrollo horizontal,https://www.inmuebles24.com/desarrollo-horizontal-en-venta-en-zapopan.html
+Inmuebles24,Guadalajara,venta-d,Desarrollo horizontal,https://www.inmuebles24.com/desarrollo-horizontal-en-venta-en-guadalajara.html
+Inmuebles24,San Pedro Tlaquepaque,venta-d,Desarrollo horizontal,https://www.inmuebles24.com/desarrollo-horizontal-en-venta-en-san-pedro-tlaquepaque.html
+Inmuebles24,Tonalá,venta-d,Desarrollo horizontal,https://www.inmuebles24.com/desarrollo-horizontal-en-venta-en-tonala.html
+Inmuebles24,Zapotlanejo,venta-d,Desarrollo horizontal,https://www.inmuebles24.com/desarrollo-horizontal-en-venta-en-zapotlanejo.html
+Inmuebles24,Juanacatlán,venta-d,Desarrollo horizontal,https://www.inmuebles24.com/desarrollo-horizontal-en-venta-en-juanacatlan.html
+Inmuebles24,Ixtlahuacán de los Membrillos,venta-d,Desarrollo horizontal,https://www.inmuebles24.com/desarrollo-horizontal-en-venta-en-ixtlahuacan-de-los-membrillos.html
+Inmuebles24,El Salto,venta-d,Desarrollo horizontal,https://www.inmuebles24.com/desarrollo-horizontal-en-venta-en-el-salto.html
+Inmuebles24,Tlajomulco de Zuñiga,venta-d,Desarrollo horizontal,https://www.inmuebles24.com/desarrollo-horizontal-en-venta-en-tlajomulco-de-zuniga.html
+Inmuebles24,Zapopan,venta-d,Desarrollo horizontal/vertical,https://www.inmuebles24.com/desarrollo-horizontal-vertical-en-venta-en-zapopan.html
+Inmuebles24,Guadalajara,venta-d,Desarrollo horizontal/vertical,https://www.inmuebles24.com/desarrollo-horizontal-vertical-en-venta-en-guadalajara.html
+Inmuebles24,San Pedro Tlaquepaque,venta-d,Desarrollo horizontal/vertical,https://www.inmuebles24.com/desarrollo-horizontal-vertical-en-venta-en-san-pedro-tlaquepaque.html
+Inmuebles24,Tonalá,venta-d,Desarrollo horizontal/vertical,https://www.inmuebles24.com/desarrollo-horizontal-vertical-en-venta-en-tonala.html
+Inmuebles24,Zapotlanejo,venta-d,Desarrollo horizontal/vertical,https://www.inmuebles24.com/desarrollo-horizontal-vertical-en-venta-en-zapotlanejo.html
+Inmuebles24,Juanacatlán,venta-d,Desarrollo horizontal/vertical,https://www.inmuebles24.com/desarrollo-horizontal-vertical-en-venta-en-juanacatlan.html
+Inmuebles24,Ixtlahuacán de los Membrillos,venta-d,Desarrollo horizontal/vertical,https://www.inmuebles24.com/desarrollo-horizontal-vertical-en-venta-en-ixtlahuacan-de-los-membrillos.html
+Inmuebles24,El Salto,venta-d,Desarrollo horizontal/vertical,https://www.inmuebles24.com/desarrollo-horizontal-vertical-en-venta-en-el-salto.html
+Inmuebles24,Tlajomulco de Zuñiga,venta-d,Desarrollo horizontal/vertical,https://www.inmuebles24.com/desarrollo-horizontal-vertical-en-venta-en-tlajomulco-de-zuniga.html
+Inmuebles24,Zapopan,venta-d,Desarrollo vertical,https://www.inmuebles24.com/desarrollo-vertical-en-venta-en-zapopan.html
+Inmuebles24,Guadalajara,venta-d,Desarrollo vertical,https://www.inmuebles24.com/desarrollo-vertical-en-venta-en-guadalajara.html
+Inmuebles24,San Pedro Tlaquepaque,venta-d,Desarrollo vertical,https://www.inmuebles24.com/desarrollo-vertical-en-venta-en-san-pedro-tlaquepaque.html
+Inmuebles24,Tonalá,venta-d,Desarrollo vertical,https://www.inmuebles24.com/desarrollo-vertical-en-venta-en-tonala.html
+Inmuebles24,Zapotlanejo,venta-d,Desarrollo vertical,https://www.inmuebles24.com/desarrollo-vertical-en-venta-en-zapotlanejo.html
+Inmuebles24,Juanacatlán,venta-d,Desarrollo vertical,https://www.inmuebles24.com/desarrollo-vertical-en-venta-en-juanacatlan.html
+Inmuebles24,Ixtlahuacán de los Membrillos,venta-d,Desarrollo vertical,https://www.inmuebles24.com/desarrollo-vertical-en-venta-en-ixtlahuacan-de-los-membrillos.html
+Inmuebles24,El Salto,venta-d,Desarrollo vertical,https://www.inmuebles24.com/desarrollo-vertical-en-venta-en-el-salto.html
+Inmuebles24,Tlajomulco de Zuñiga,venta-d,Desarrollo vertical,https://www.inmuebles24.com/desarrollo-vertical-en-venta-en-tlajomulco-de-zuniga.html
+Inmuebles24,Zapopan,venta,Edificio,https://www.inmuebles24.com/edificio-en-venta-en-zapopan.html
+Inmuebles24,Guadalajara,venta,Edificio,https://www.inmuebles24.com/edificio-en-venta-en-guadalajara.html
+Inmuebles24,San Pedro Tlaquepaque,venta,Edificio,https://www.inmuebles24.com/edificio-en-venta-en-san-pedro-tlaquepaque.html
+Inmuebles24,Tonalá,venta,Edificio,https://www.inmuebles24.com/edificio-en-venta-en-tonala.html
+Inmuebles24,Zapotlanejo,venta,Edificio,https://www.inmuebles24.com/edificio-en-venta-en-zapotlanejo.html
+Inmuebles24,Juanacatlán,venta,Edificio,https://www.inmuebles24.com/edificio-en-venta-en-juanacatlan.html
+Inmuebles24,Ixtlahuacán de los Membrillos,venta,Edificio,https://www.inmuebles24.com/edificio-en-venta-en-ixtlahuacan-de-los-membrillos.html
+Inmuebles24,El Salto,venta,Edificio,https://www.inmuebles24.com/edificio-en-venta-en-el-salto.html
+Inmuebles24,Tlajomulco de Zuñiga,venta,Edificio,https://www.inmuebles24.com/edificio-en-venta-en-tlajomulco-de-zuniga.html
+Inmuebles24,Zapopan,venta,Huerta,https://www.inmuebles24.com/huerta-en-venta-en-zapopan.html
+Inmuebles24,Guadalajara,venta,Huerta,https://www.inmuebles24.com/huerta-en-venta-en-guadalajara.html
+Inmuebles24,San Pedro Tlaquepaque,venta,Huerta,https://www.inmuebles24.com/huerta-en-venta-en-san-pedro-tlaquepaque.html
+Inmuebles24,Tonalá,venta,Huerta,https://www.inmuebles24.com/huerta-en-venta-en-tonala.html
+Inmuebles24,Zapotlanejo,venta,Huerta,https://www.inmuebles24.com/huerta-en-venta-en-zapotlanejo.html
+Inmuebles24,Juanacatlán,venta,Huerta,https://www.inmuebles24.com/huerta-en-venta-en-juanacatlan.html
+Inmuebles24,Ixtlahuacán de los Membrillos,venta,Huerta,https://www.inmuebles24.com/huerta-en-venta-en-ixtlahuacan-de-los-membrillos.html
+Inmuebles24,El Salto,venta,Huerta,https://www.inmuebles24.com/huerta-en-venta-en-el-salto.html
+Inmuebles24,Tlajomulco de Zuñiga,venta,Huerta,https://www.inmuebles24.com/huerta-en-venta-en-tlajomulco-de-zuniga.html
+Inmuebles24,Zapopan,venta,Inmueble productivo urbano,https://www.inmuebles24.com/inmueble-productivo-urbano-en-venta-en-zapopan.html
+Inmuebles24,Guadalajara,venta,Inmueble productivo urbano,https://www.inmuebles24.com/inmueble-productivo-urbano-en-venta-en-guadalajara.html
+Inmuebles24,San Pedro Tlaquepaque,venta,Inmueble productivo urbano,https://www.inmuebles24.com/inmueble-productivo-urbano-en-venta-en-san-pedro-tlaquepaque.html
+Inmuebles24,Tonalá,venta,Inmueble productivo urbano,https://www.inmuebles24.com/inmueble-productivo-urbano-en-venta-en-tonala.html
+Inmuebles24,Zapotlanejo,venta,Inmueble productivo urbano,https://www.inmuebles24.com/inmueble-productivo-urbano-en-venta-en-zapotlanejo.html
+Inmuebles24,Juanacatlán,venta,Inmueble productivo urbano,https://www.inmuebles24.com/inmueble-productivo-urbano-en-venta-en-juanacatlan.html
+Inmuebles24,Ixtlahuacán de los Membrillos,venta,Inmueble productivo urbano,https://www.inmuebles24.com/inmueble-productivo-urbano-en-venta-en-ixtlahuacan-de-los-membrillos.html
+Inmuebles24,El Salto,venta,Inmueble productivo urbano,https://www.inmuebles24.com/inmueble-productivo-urbano-en-venta-en-el-salto.html
+Inmuebles24,Tlajomulco de Zuñiga,venta,Inmueble productivo urbano,https://www.inmuebles24.com/inmueble-productivo-urbano-en-venta-en-tlajomulco-de-zuniga.html
+Inmuebles24,Zapopan,venta,Local en centro comercial,https://www.inmuebles24.com/local-en-centro-comercial-en-venta-en-zapopan.html
+Inmuebles24,Guadalajara,venta,Local en centro comercial,https://www.inmuebles24.com/local-en-centro-comercial-en-venta-en-guadalajara.html
+Inmuebles24,San Pedro Tlaquepaque,venta,Local en centro comercial,https://www.inmuebles24.com/local-en-centro-comercial-en-venta-en-san-pedro-tlaquepaque.html
+Inmuebles24,Tonalá,venta,Local en centro comercial,https://www.inmuebles24.com/local-en-centro-comercial-en-venta-en-tonala.html
+Inmuebles24,Zapotlanejo,venta,Local en centro comercial,https://www.inmuebles24.com/local-en-centro-comercial-en-venta-en-zapotlanejo.html
+Inmuebles24,Juanacatlán,venta,Local en centro comercial,https://www.inmuebles24.com/local-en-centro-comercial-en-venta-en-juanacatlan.html
+Inmuebles24,Ixtlahuacán de los Membrillos,venta,Local en centro comercial,https://www.inmuebles24.com/local-en-centro-comercial-en-venta-en-ixtlahuacan-de-los-membrillos.html
+Inmuebles24,El Salto,venta,Local en centro comercial,https://www.inmuebles24.com/local-en-centro-comercial-en-venta-en-el-salto.html
+Inmuebles24,Tlajomulco de Zuñiga,venta,Local en centro comercial,https://www.inmuebles24.com/local-en-centro-comercial-en-venta-en-tlajomulco-de-zuniga.html
+Inmuebles24,Zapopan,venta,Locales comerciales,https://www.inmuebles24.com/locales-comerciales-en-venta-en-zapopan.html
+Inmuebles24,Guadalajara,venta,Locales comerciales,https://www.inmuebles24.com/locales-comerciales-en-venta-en-guadalajara.html
+Inmuebles24,San Pedro Tlaquepaque,venta,Locales comerciales,https://www.inmuebles24.com/locales-comerciales-en-venta-en-san-pedro-tlaquepaque.html
+Inmuebles24,Tonalá,venta,Locales comerciales,https://www.inmuebles24.com/locales-comerciales-en-venta-en-tonala.html
+Inmuebles24,Zapotlanejo,venta,Locales comerciales,https://www.inmuebles24.com/locales-comerciales-en-venta-en-zapotlanejo.html
+Inmuebles24,Juanacatlán,venta,Locales comerciales,https://www.inmuebles24.com/locales-comerciales-en-venta-en-juanacatlan.html
+Inmuebles24,Ixtlahuacán de los Membrillos,venta,Locales comerciales,https://www.inmuebles24.com/locales-comerciales-en-venta-en-ixtlahuacan-de-los-membrillos.html
+Inmuebles24,El Salto,venta,Locales comerciales,https://www.inmuebles24.com/locales-comerciales-en-venta-en-el-salto.html
+Inmuebles24,Tlajomulco de Zuñiga,venta,Locales comerciales,https://www.inmuebles24.com/locales-comerciales-en-venta-en-tlajomulco-de-zuniga.html
+Inmuebles24,Zapopan,venta,Nave industrial,https://www.inmuebles24.com/nave-industrial-en-venta-en-zapopan.html
+Inmuebles24,Guadalajara,venta,Nave industrial,https://www.inmuebles24.com/nave-industrial-en-venta-en-guadalajara.html
+Inmuebles24,San Pedro Tlaquepaque,venta,Nave industrial,https://www.inmuebles24.com/nave-industrial-en-venta-en-san-pedro-tlaquepaque.html
+Inmuebles24,Tonalá,venta,Nave industrial,https://www.inmuebles24.com/nave-industrial-en-venta-en-tonala.html
+Inmuebles24,Zapotlanejo,venta,Nave industrial,https://www.inmuebles24.com/nave-industrial-en-venta-en-zapotlanejo.html
+Inmuebles24,Juanacatlán,venta,Nave industrial,https://www.inmuebles24.com/nave-industrial-en-venta-en-juanacatlan.html
+Inmuebles24,Ixtlahuacán de los Membrillos,venta,Nave industrial,https://www.inmuebles24.com/nave-industrial-en-venta-en-ixtlahuacan-de-los-membrillos.html
+Inmuebles24,El Salto,venta,Nave industrial,https://www.inmuebles24.com/nave-industrial-en-venta-en-el-salto.html
+Inmuebles24,Tlajomulco de Zuñiga,venta,Nave industrial,https://www.inmuebles24.com/nave-industrial-en-venta-en-tlajomulco-de-zuniga.html
+Inmuebles24,Zapopan,venta,Oficinas,https://www.inmuebles24.com/oficinas-en-venta-en-zapopan.html
+Inmuebles24,Guadalajara,venta,Oficinas,https://www.inmuebles24.com/oficinas-en-venta-en-guadalajara.html
+Inmuebles24,San Pedro Tlaquepaque,venta,Oficinas,https://www.inmuebles24.com/oficinas-en-venta-en-san-pedro-tlaquepaque.html
+Inmuebles24,Tonalá,venta,Oficinas,https://www.inmuebles24.com/oficinas-en-venta-en-tonala.html
+Inmuebles24,Zapotlanejo,venta,Oficinas,https://www.inmuebles24.com/oficinas-en-venta-en-zapotlanejo.html
+Inmuebles24,Juanacatlán,venta,Oficinas,https://www.inmuebles24.com/oficinas-en-venta-en-juanacatlan.html
+Inmuebles24,Ixtlahuacán de los Membrillos,venta,Oficinas,https://www.inmuebles24.com/oficinas-en-venta-en-ixtlahuacan-de-los-membrillos.html
+Inmuebles24,El Salto,venta,Oficinas,https://www.inmuebles24.com/oficinas-en-venta-en-el-salto.html
+Inmuebles24,Tlajomulco de Zuñiga,venta,Oficinas,https://www.inmuebles24.com/oficinas-en-venta-en-tlajomulco-de-zuniga.html
+Inmuebles24,Zapopan,venta,Quinta,https://www.inmuebles24.com/quinta-en-venta-en-zapopan.html
+Inmuebles24,Guadalajara,venta,Quinta,https://www.inmuebles24.com/quinta-en-venta-en-guadalajara.html
+Inmuebles24,San Pedro Tlaquepaque,venta,Quinta,https://www.inmuebles24.com/quinta-en-venta-en-san-pedro-tlaquepaque.html
+Inmuebles24,Tonalá,venta,Quinta,https://www.inmuebles24.com/quinta-en-venta-en-tonala.html
+Inmuebles24,Zapotlanejo,venta,Quinta,https://www.inmuebles24.com/quinta-en-venta-en-zapotlanejo.html
+Inmuebles24,Juanacatlán,venta,Quinta,https://www.inmuebles24.com/quinta-en-venta-en-juanacatlan.html
+Inmuebles24,Ixtlahuacán de los Membrillos,venta,Quinta,https://www.inmuebles24.com/quinta-en-venta-en-ixtlahuacan-de-los-membrillos.html
+Inmuebles24,El Salto,venta,Quinta,https://www.inmuebles24.com/quinta-en-venta-en-el-salto.html
+Inmuebles24,Tlajomulco de Zuñiga,venta,Quinta,https://www.inmuebles24.com/quinta-en-venta-en-tlajomulco-de-zuniga.html
+Inmuebles24,Zapopan,venta,Terreno comercial,https://www.inmuebles24.com/terreno-comercial-en-venta-en-zapopan.html
+Inmuebles24,Guadalajara,venta,Terreno comercial,https://www.inmuebles24.com/terreno-comercial-en-venta-en-guadalajara.html
+Inmuebles24,San Pedro Tlaquepaque,venta,Terreno comercial,https://www.inmuebles24.com/terreno-comercial-en-venta-en-san-pedro-tlaquepaque.html
+Inmuebles24,Tonalá,venta,Terreno comercial,https://www.inmuebles24.com/terreno-comercial-en-venta-en-tonala.html
+Inmuebles24,Zapotlanejo,venta,Terreno comercial,https://www.inmuebles24.com/terreno-comercial-en-venta-en-zapotlanejo.html
+Inmuebles24,Juanacatlán,venta,Terreno comercial,https://www.inmuebles24.com/terreno-comercial-en-venta-en-juanacatlan.html
+Inmuebles24,Ixtlahuacán de los Membrillos,venta,Terreno comercial,https://www.inmuebles24.com/terreno-comercial-en-venta-en-ixtlahuacan-de-los-membrillos.html
+Inmuebles24,El Salto,venta,Terreno comercial,https://www.inmuebles24.com/terreno-comercial-en-venta-en-el-salto.html
+Inmuebles24,Tlajomulco de Zuñiga,venta,Terreno comercial,https://www.inmuebles24.com/terreno-comercial-en-venta-en-tlajomulco-de-zuniga.html
+Inmuebles24,Zapopan,venta,Terreno industrial,https://www.inmuebles24.com/terreno-industrial-en-venta-en-zapopan.html
+Inmuebles24,Guadalajara,venta,Terreno industrial,https://www.inmuebles24.com/terreno-industrial-en-venta-en-guadalajara.html
+Inmuebles24,San Pedro Tlaquepaque,venta,Terreno industrial,https://www.inmuebles24.com/terreno-industrial-en-venta-en-san-pedro-tlaquepaque.html
+Inmuebles24,Tonalá,venta,Terreno industrial,https://www.inmuebles24.com/terreno-industrial-en-venta-en-tonala.html
+Inmuebles24,Zapotlanejo,venta,Terreno industrial,https://www.inmuebles24.com/terreno-industrial-en-venta-en-zapotlanejo.html
+Inmuebles24,Juanacatlán,venta,Terreno industrial,https://www.inmuebles24.com/terreno-industrial-en-venta-en-juanacatlan.html
+Inmuebles24,Ixtlahuacán de los Membrillos,venta,Terreno industrial,https://www.inmuebles24.com/terreno-industrial-en-venta-en-ixtlahuacan-de-los-membrillos.html
+Inmuebles24,El Salto,venta,Terreno industrial,https://www.inmuebles24.com/terreno-industrial-en-venta-en-el-salto.html
+Inmuebles24,Tlajomulco de Zuñiga,venta,Terreno industrial,https://www.inmuebles24.com/terreno-industrial-en-venta-en-tlajomulco-de-zuniga.html
+Inmuebles24,Zapopan,venta,Terrenos,https://www.inmuebles24.com/terrenos-en-venta-en-zapopan.html
+Inmuebles24,Guadalajara,venta,Terrenos,https://www.inmuebles24.com/terrenos-en-venta-en-guadalajara.html
+Inmuebles24,San Pedro Tlaquepaque,venta,Terrenos,https://www.inmuebles24.com/terrenos-en-venta-en-san-pedro-tlaquepaque.html
+Inmuebles24,Tonalá,venta,Terrenos,https://www.inmuebles24.com/terrenos-en-venta-en-tonala.html
+Inmuebles24,Zapotlanejo,venta,Terrenos,https://www.inmuebles24.com/terrenos-en-venta-en-zapotlanejo.html
+Inmuebles24,Juanacatlán,venta,Terrenos,https://www.inmuebles24.com/terrenos-en-venta-en-juanacatlan.html
+Inmuebles24,Ixtlahuacán de los Membrillos,venta,Terrenos,https://www.inmuebles24.com/terrenos-en-venta-en-ixtlahuacan-de-los-membrillos.html
+Inmuebles24,El Salto,venta,Terrenos,https://www.inmuebles24.com/terrenos-en-venta-en-el-salto.html
+Inmuebles24,Tlajomulco de Zuñiga,venta,Terrenos,https://www.inmuebles24.com/terrenos-en-venta-en-tlajomulco-de-zuniga.html
+Inmuebles24,Zapopan,venta,Villa,https://www.inmuebles24.com/villa-en-venta-en-zapopan.html
+Inmuebles24,Guadalajara,venta,Villa,https://www.inmuebles24.com/villa-en-venta-en-guadalajara.html
+Inmuebles24,San Pedro Tlaquepaque,venta,Villa,https://www.inmuebles24.com/villa-en-venta-en-san-pedro-tlaquepaque.html
+Inmuebles24,Tonalá,venta,Villa,https://www.inmuebles24.com/villa-en-venta-en-tonala.html
+Inmuebles24,Zapotlanejo,venta,Villa,https://www.inmuebles24.com/villa-en-venta-en-zapotlanejo.html
+Inmuebles24,Juanacatlán,venta,Villa,https://www.inmuebles24.com/villa-en-venta-en-juanacatlan.html
+Inmuebles24,Ixtlahuacán de los Membrillos,venta,Villa,https://www.inmuebles24.com/villa-en-venta-en-ixtlahuacan-de-los-membrillos.html
+Inmuebles24,El Salto,venta,Villa,https://www.inmuebles24.com/villa-en-venta-en-el-salto.html
+Inmuebles24,Tlajomulco de Zuñiga,venta,Villa,https://www.inmuebles24.com/villa-en-venta-en-tlajomulco-de-zuniga.html
+Inmuebles24,Zapopan,venta-d,Desarrollo horizontal,https://www.inmuebles24.com/desarrollo-horizontal-en-venta-en-zapopan.html
+Inmuebles24,Guadalajara,venta-d,Desarrollo horizontal,https://www.inmuebles24.com/desarrollo-horizontal-en-venta-en-guadalajara.html
+Inmuebles24,San Pedro Tlaquepaque,venta-d,Desarrollo horizontal,https://www.inmuebles24.com/desarrollo-horizontal-en-venta-en-san-pedro-tlaquepaque.html
+Inmuebles24,Tonalá,venta-d,Desarrollo horizontal,https://www.inmuebles24.com/desarrollo-horizontal-en-venta-en-tonala.html
+Inmuebles24,Zapotlanejo,venta-d,Desarrollo horizontal,https://www.inmuebles24.com/desarrollo-horizontal-en-venta-en-zapotlanejo.html
+Inmuebles24,Juanacatlán,venta-d,Desarrollo horizontal,https://www.inmuebles24.com/desarrollo-horizontal-en-venta-en-juanacatlan.html
+Inmuebles24,Ixtlahuacán de los Membrillos,venta-d,Desarrollo horizontal,https://www.inmuebles24.com/desarrollo-horizontal-en-venta-en-ixtlahuacan-de-los-membrillos.html
+Inmuebles24,El Salto,venta-d,Desarrollo horizontal,https://www.inmuebles24.com/desarrollo-horizontal-en-venta-en-el-salto.html
+Inmuebles24,Tlajomulco de Zuñiga,venta-d,Desarrollo horizontal,https://www.inmuebles24.com/desarrollo-horizontal-en-venta-en-tlajomulco-de-zuniga.html
+Inmuebles24,Zapopan,venta-d,Desarrollo horizontal/vertical,https://www.inmuebles24.com/desarrollo-horizontal-vertical-en-venta-en-zapopan.html
+Inmuebles24,Guadalajara,venta-d,Desarrollo horizontal/vertical,https://www.inmuebles24.com/desarrollo-horizontal-vertical-en-venta-en-guadalajara.html
+Inmuebles24,San Pedro Tlaquepaque,venta-d,Desarrollo horizontal/vertical,https://www.inmuebles24.com/desarrollo-horizontal-vertical-en-venta-en-san-pedro-tlaquepaque.html
+Inmuebles24,Tonalá,venta-d,Desarrollo horizontal/vertical,https://www.inmuebles24.com/desarrollo-horizontal-vertical-en-venta-en-tonala.html
+Inmuebles24,Zapotlanejo,venta-d,Desarrollo horizontal/vertical,https://www.inmuebles24.com/desarrollo-horizontal-vertical-en-venta-en-zapotlanejo.html
+Inmuebles24,Juanacatlán,venta-d,Desarrollo horizontal/vertical,https://www.inmuebles24.com/desarrollo-horizontal-vertical-en-venta-en-juanacatlan.html
+Inmuebles24,Ixtlahuacán de los Membrillos,venta-d,Desarrollo horizontal/vertical,https://www.inmuebles24.com/desarrollo-horizontal-vertical-en-venta-en-ixtlahuacan-de-los-membrillos.html
+Inmuebles24,El Salto,venta-d,Desarrollo horizontal/vertical,https://www.inmuebles24.com/desarrollo-horizontal-vertical-en-venta-en-el-salto.html
+Inmuebles24,Tlajomulco de Zuñiga,venta-d,Desarrollo horizontal/vertical,https://www.inmuebles24.com/desarrollo-horizontal-vertical-en-venta-en-tlajomulco-de-zuniga.html
+Inmuebles24,Zapopan,venta-d,Desarrollo vertical,https://www.inmuebles24.com/desarrollo-vertical-en-venta-en-zapopan.html
+Inmuebles24,Guadalajara,venta-d,Desarrollo vertical,https://www.inmuebles24.com/desarrollo-vertical-en-venta-en-guadalajara.html
+Inmuebles24,San Pedro Tlaquepaque,venta-d,Desarrollo vertical,https://www.inmuebles24.com/desarrollo-vertical-en-venta-en-san-pedro-tlaquepaque.html
+Inmuebles24,Tonalá,venta-d,Desarrollo vertical,https://www.inmuebles24.com/desarrollo-vertical-en-venta-en-tonala.html
+Inmuebles24,Zapotlanejo,venta-d,Desarrollo vertical,https://www.inmuebles24.com/desarrollo-vertical-en-venta-en-zapotlanejo.html
+Inmuebles24,Juanacatlán,venta-d,Desarrollo vertical,https://www.inmuebles24.com/desarrollo-vertical-en-venta-en-juanacatlan.html
+Inmuebles24,Ixtlahuacán de los Membrillos,venta-d,Desarrollo vertical,https://www.inmuebles24.com/desarrollo-vertical-en-venta-en-ixtlahuacan-de-los-membrillos.html
+Inmuebles24,El Salto,venta-d,Desarrollo vertical,https://www.inmuebles24.com/desarrollo-vertical-en-venta-en-el-salto.html
+Inmuebles24,Tlajomulco de Zuñiga,venta-d,Desarrollo vertical,https://www.inmuebles24.com/desarrollo-vertical-en-venta-en-tlajomulco-de-zuniga.html
+Inmuebles24,Zapopan,venta-r,Bodegas comerciales,https://www.inmuebles24.com/bodegas-comerciales-en-venta-en-zapopan-q-remate.html
+Inmuebles24,Guadalajara,venta-r,Bodegas comerciales,https://www.inmuebles24.com/bodegas-comerciales-en-venta-en-guadalajara-q-remate.html
+Inmuebles24,San Pedro Tlaquepaque,venta-r,Bodegas comerciales,https://www.inmuebles24.com/bodegas-comerciales-en-venta-en-san-pedro-tlaquepaque-q-remate.html
+Inmuebles24,Tonalá,venta-r,Bodegas comerciales,https://www.inmuebles24.com/bodegas-comerciales-en-venta-en-tonala-q-remate.html
+Inmuebles24,Zapotlanejo,venta-r,Bodegas comerciales,https://www.inmuebles24.com/bodegas-comerciales-en-venta-en-zapotlanejo-q-remate.html
+Inmuebles24,Juanacatlán,venta-r,Bodegas comerciales,https://www.inmuebles24.com/bodegas-comerciales-en-venta-en-juanacatlan-q-remate.html
+Inmuebles24,Ixtlahuacán de los Membrillos,venta-r,Bodegas comerciales,https://www.inmuebles24.com/bodegas-comerciales-en-venta-en-ixtlahuacan-de-los-membrillos-q-remate.html
+Inmuebles24,El Salto,venta-r,Bodegas comerciales,https://www.inmuebles24.com/bodegas-comerciales-en-venta-en-el-salto-q-remate.html
+Inmuebles24,Tlajomulco de Zuñiga,venta-r,Bodegas comerciales,https://www.inmuebles24.com/bodegas-comerciales-en-venta-en-tlajomulco-de-zuniga-q-remate.html
+Inmuebles24,Zapopan,venta-r,Casa en condominio,https://www.inmuebles24.com/casa-en-condominio-en-venta-en-zapopan-q-remate.html
+Inmuebles24,Guadalajara,venta-r,Casa en condominio,https://www.inmuebles24.com/casa-en-condominio-en-venta-en-guadalajara-q-remate.html
+Inmuebles24,San Pedro Tlaquepaque,venta-r,Casa en condominio,https://www.inmuebles24.com/casa-en-condominio-en-venta-en-san-pedro-tlaquepaque-q-remate.html
+Inmuebles24,Tonalá,venta-r,Casa en condominio,https://www.inmuebles24.com/casa-en-condominio-en-venta-en-tonala-q-remate.html
+Inmuebles24,Zapotlanejo,venta-r,Casa en condominio,https://www.inmuebles24.com/casa-en-condominio-en-venta-en-zapotlanejo-q-remate.html
+Inmuebles24,Juanacatlán,venta-r,Casa en condominio,https://www.inmuebles24.com/casa-en-condominio-en-venta-en-juanacatlan-q-remate.html
+Inmuebles24,Ixtlahuacán de los Membrillos,venta-r,Casa en condominio,https://www.inmuebles24.com/casa-en-condominio-en-venta-en-ixtlahuacan-de-los-membrillos-q-remate.html
+Inmuebles24,El Salto,venta-r,Casa en condominio,https://www.inmuebles24.com/casa-en-condominio-en-venta-en-el-salto-q-remate.html
+Inmuebles24,Tlajomulco de Zuñiga,venta-r,Casa en condominio,https://www.inmuebles24.com/casa-en-condominio-en-venta-en-tlajomulco-de-zuniga-q-remate.html
+Inmuebles24,Zapopan,venta-r,Casa uso de suelo,https://www.inmuebles24.com/casa-uso-de-suelo-en-venta-en-zapopan-q-remate.html
+Inmuebles24,Guadalajara,venta-r,Casa uso de suelo,https://www.inmuebles24.com/casa-uso-de-suelo-en-venta-en-guadalajara-q-remate.html
+Inmuebles24,San Pedro Tlaquepaque,venta-r,Casa uso de suelo,https://www.inmuebles24.com/casa-uso-de-suelo-en-venta-en-san-pedro-tlaquepaque-q-remate.html
+Inmuebles24,Tonalá,venta-r,Casa uso de suelo,https://www.inmuebles24.com/casa-uso-de-suelo-en-venta-en-tonala-q-remate.html
+Inmuebles24,Zapotlanejo,venta-r,Casa uso de suelo,https://www.inmuebles24.com/casa-uso-de-suelo-en-venta-en-zapotlanejo-q-remate.html
+Inmuebles24,Juanacatlán,venta-r,Casa uso de suelo,https://www.inmuebles24.com/casa-uso-de-suelo-en-venta-en-juanacatlan-q-remate.html
+Inmuebles24,Ixtlahuacán de los Membrillos,venta-r,Casa uso de suelo,https://www.inmuebles24.com/casa-uso-de-suelo-en-venta-en-ixtlahuacan-de-los-membrillos-q-remate.html
+Inmuebles24,El Salto,venta-r,Casa uso de suelo,https://www.inmuebles24.com/casa-uso-de-suelo-en-venta-en-el-salto-q-remate.html
+Inmuebles24,Tlajomulco de Zuñiga,venta-r,Casa uso de suelo,https://www.inmuebles24.com/casa-uso-de-suelo-en-venta-en-tlajomulco-de-zuniga-q-remate.html
+Inmuebles24,Zapopan,venta-r,Casas,https://www.inmuebles24.com/casas-en-venta-en-zapopan-q-remate.html
+Inmuebles24,Guadalajara,venta-r,Casas,https://www.inmuebles24.com/casas-en-venta-en-guadalajara-q-remate.html
+Inmuebles24,San Pedro Tlaquepaque,venta-r,Casas,https://www.inmuebles24.com/casas-en-venta-en-san-pedro-tlaquepaque-q-remate.html
+Inmuebles24,Tonalá,venta-r,Casas,https://www.inmuebles24.com/casas-en-venta-en-tonala-q-remate.html
+Inmuebles24,Zapotlanejo,venta-r,Casas,https://www.inmuebles24.com/casas-en-venta-en-zapotlanejo-q-remate.html
+Inmuebles24,Juanacatlán,venta-r,Casas,https://www.inmuebles24.com/casas-en-venta-en-juanacatlan-q-remate.html
+Inmuebles24,Ixtlahuacán de los Membrillos,venta-r,Casas,https://www.inmuebles24.com/casas-en-venta-en-ixtlahuacan-de-los-membrillos-q-remate.html
+Inmuebles24,El Salto,venta-r,Casas,https://www.inmuebles24.com/casas-en-venta-en-el-salto-q-remate.html
+Inmuebles24,Tlajomulco de Zuñiga,venta-r,Casas,https://www.inmuebles24.com/casas-en-venta-en-tlajomulco-de-zuniga-q-remate.html
+Inmuebles24,Zapopan,venta-r,Dúplex,https://www.inmuebles24.com/duplex-en-venta-en-zapopan-q-remate.html
+Inmuebles24,Guadalajara,venta-r,Dúplex,https://www.inmuebles24.com/duplex-en-venta-en-guadalajara-q-remate.html
+Inmuebles24,San Pedro Tlaquepaque,venta-r,Dúplex,https://www.inmuebles24.com/duplex-en-venta-en-san-pedro-tlaquepaque-q-remate.html
+Inmuebles24,Tonalá,venta-r,Dúplex,https://www.inmuebles24.com/duplex-en-venta-en-tonala-q-remate.html
+Inmuebles24,Zapotlanejo,venta-r,Dúplex,https://www.inmuebles24.com/duplex-en-venta-en-zapotlanejo-q-remate.html
+Inmuebles24,Juanacatlán,venta-r,Dúplex,https://www.inmuebles24.com/duplex-en-venta-en-juanacatlan-q-remate.html
+Inmuebles24,Ixtlahuacán de los Membrillos,venta-r,Dúplex,https://www.inmuebles24.com/duplex-en-venta-en-ixtlahuacan-de-los-membrillos-q-remate.html
+Inmuebles24,El Salto,venta-r,Dúplex,https://www.inmuebles24.com/duplex-en-venta-en-el-salto-q-remate.html
+Inmuebles24,Tlajomulco de Zuñiga,venta-r,Dúplex,https://www.inmuebles24.com/duplex-en-venta-en-tlajomulco-de-zuniga-q-remate.html
+Inmuebles24,Zapopan,venta-r,Departamento compartido,https://www.inmuebles24.com/departamento-compartido-en-venta-en-zapopan-q-remate.html
+Inmuebles24,Guadalajara,venta-r,Departamento compartido,https://www.inmuebles24.com/departamento-compartido-en-venta-en-guadalajara-q-remate.html
+Inmuebles24,San Pedro Tlaquepaque,venta-r,Departamento compartido,https://www.inmuebles24.com/departamento-compartido-en-venta-en-san-pedro-tlaquepaque-q-remate.html
+Inmuebles24,Tonalá,venta-r,Departamento compartido,https://www.inmuebles24.com/departamento-compartido-en-venta-en-tonala-q-remate.html
+Inmuebles24,Zapotlanejo,venta-r,Departamento compartido,https://www.inmuebles24.com/departamento-compartido-en-venta-en-zapotlanejo-q-remate.html
+Inmuebles24,Juanacatlán,venta-r,Departamento compartido,https://www.inmuebles24.com/departamento-compartido-en-venta-en-juanacatlan-q-remate.html
+Inmuebles24,Ixtlahuacán de los Membrillos,venta-r,Departamento compartido,https://www.inmuebles24.com/departamento-compartido-en-venta-en-ixtlahuacan-de-los-membrillos-q-remate.html
+Inmuebles24,El Salto,venta-r,Departamento compartido,https://www.inmuebles24.com/departamento-compartido-en-venta-en-el-salto-q-remate.html
+Inmuebles24,Tlajomulco de Zuñiga,venta-r,Departamento compartido,https://www.inmuebles24.com/departamento-compartido-en-venta-en-tlajomulco-de-zuniga-q-remate.html
+Inmuebles24,Zapopan,venta-r,Departamentos,https://www.inmuebles24.com/departamentos-en-venta-en-zapopan-q-remate.html
+Inmuebles24,Guadalajara,venta-r,Departamentos,https://www.inmuebles24.com/departamentos-en-venta-en-guadalajara-q-remate.html
+Inmuebles24,San Pedro Tlaquepaque,venta-r,Departamentos,https://www.inmuebles24.com/departamentos-en-venta-en-san-pedro-tlaquepaque-q-remate.html
+Inmuebles24,Tonalá,venta-r,Departamentos,https://www.inmuebles24.com/departamentos-en-venta-en-tonala-q-remate.html
+Inmuebles24,Zapotlanejo,venta-r,Departamentos,https://www.inmuebles24.com/departamentos-en-venta-en-zapotlanejo-q-remate.html
+Inmuebles24,Juanacatlán,venta-r,Departamentos,https://www.inmuebles24.com/departamentos-en-venta-en-juanacatlan-q-remate.html
+Inmuebles24,Ixtlahuacán de los Membrillos,venta-r,Departamentos,https://www.inmuebles24.com/departamentos-en-venta-en-ixtlahuacan-de-los-membrillos-q-remate.html
+Inmuebles24,El Salto,venta-r,Departamentos,https://www.inmuebles24.com/departamentos-en-venta-en-el-salto-q-remate.html
+Inmuebles24,Tlajomulco de Zuñiga,venta-r,Departamentos,https://www.inmuebles24.com/departamentos-en-venta-en-tlajomulco-de-zuniga-q-remate.html
+Inmuebles24,Zapopan,venta-r,Desarrollo horizontal,https://www.inmuebles24.com/desarrollo-horizontal-en-venta-en-zapopan-q-remate.html
+Inmuebles24,Guadalajara,venta-r,Desarrollo horizontal,https://www.inmuebles24.com/desarrollo-horizontal-en-venta-en-guadalajara-q-remate.html
+Inmuebles24,San Pedro Tlaquepaque,venta-r,Desarrollo horizontal,https://www.inmuebles24.com/desarrollo-horizontal-en-venta-en-san-pedro-tlaquepaque-q-remate.html
+Inmuebles24,Tonalá,venta-r,Desarrollo horizontal,https://www.inmuebles24.com/desarrollo-horizontal-en-venta-en-tonala-q-remate.html
+Inmuebles24,Zapotlanejo,venta-r,Desarrollo horizontal,https://www.inmuebles24.com/desarrollo-horizontal-en-venta-en-zapotlanejo-q-remate.html
+Inmuebles24,Juanacatlán,venta-r,Desarrollo horizontal,https://www.inmuebles24.com/desarrollo-horizontal-en-venta-en-juanacatlan-q-remate.html
+Inmuebles24,Ixtlahuacán de los Membrillos,venta-r,Desarrollo horizontal,https://www.inmuebles24.com/desarrollo-horizontal-en-venta-en-ixtlahuacan-de-los-membrillos-q-remate.html
+Inmuebles24,El Salto,venta-r,Desarrollo horizontal,https://www.inmuebles24.com/desarrollo-horizontal-en-venta-en-el-salto-q-remate.html
+Inmuebles24,Tlajomulco de Zuñiga,venta-r,Desarrollo horizontal,https://www.inmuebles24.com/desarrollo-horizontal-en-venta-en-tlajomulco-de-zuniga-q-remate.html
+Inmuebles24,Zapopan,venta-r,Desarrollo horizontal/vertical,https://www.inmuebles24.com/desarrollo-horizontal-vertical-en-venta-en-zapopan-q-remate.html
+Inmuebles24,Guadalajara,venta-r,Desarrollo horizontal/vertical,https://www.inmuebles24.com/desarrollo-horizontal-vertical-en-venta-en-guadalajara-q-remate.html
+Inmuebles24,San Pedro Tlaquepaque,venta-r,Desarrollo horizontal/vertical,https://www.inmuebles24.com/desarrollo-horizontal-vertical-en-venta-en-san-pedro-tlaquepaque-q-remate.html
+Inmuebles24,Tonalá,venta-r,Desarrollo horizontal/vertical,https://www.inmuebles24.com/desarrollo-horizontal-vertical-en-venta-en-tonala-q-remate.html
+Inmuebles24,Zapotlanejo,venta-r,Desarrollo horizontal/vertical,https://www.inmuebles24.com/desarrollo-horizontal-vertical-en-venta-en-zapotlanejo-q-remate.html
+Inmuebles24,Juanacatlán,venta-r,Desarrollo horizontal/vertical,https://www.inmuebles24.com/desarrollo-horizontal-vertical-en-venta-en-juanacatlan-q-remate.html
+Inmuebles24,Ixtlahuacán de los Membrillos,venta-r,Desarrollo horizontal/vertical,https://www.inmuebles24.com/desarrollo-horizontal-vertical-en-venta-en-ixtlahuacan-de-los-membrillos-q-remate.html
+Inmuebles24,El Salto,venta-r,Desarrollo horizontal/vertical,https://www.inmuebles24.com/desarrollo-horizontal-vertical-en-venta-en-el-salto-q-remate.html
+Inmuebles24,Tlajomulco de Zuñiga,venta-r,Desarrollo horizontal/vertical,https://www.inmuebles24.com/desarrollo-horizontal-vertical-en-venta-en-tlajomulco-de-zuniga-q-remate.html
+Inmuebles24,Zapopan,venta-r,Desarrollo vertical,https://www.inmuebles24.com/desarrollo-vertical-en-venta-en-zapopan-q-remate.html
+Inmuebles24,Guadalajara,venta-r,Desarrollo vertical,https://www.inmuebles24.com/desarrollo-vertical-en-venta-en-guadalajara-q-remate.html
+Inmuebles24,San Pedro Tlaquepaque,venta-r,Desarrollo vertical,https://www.inmuebles24.com/desarrollo-vertical-en-venta-en-san-pedro-tlaquepaque-q-remate.html
+Inmuebles24,Tonalá,venta-r,Desarrollo vertical,https://www.inmuebles24.com/desarrollo-vertical-en-venta-en-tonala-q-remate.html
+Inmuebles24,Zapotlanejo,venta-r,Desarrollo vertical,https://www.inmuebles24.com/desarrollo-vertical-en-venta-en-zapotlanejo-q-remate.html
+Inmuebles24,Juanacatlán,venta-r,Desarrollo vertical,https://www.inmuebles24.com/desarrollo-vertical-en-venta-en-juanacatlan-q-remate.html
+Inmuebles24,Ixtlahuacán de los Membrillos,venta-r,Desarrollo vertical,https://www.inmuebles24.com/desarrollo-vertical-en-venta-en-ixtlahuacan-de-los-membrillos-q-remate.html
+Inmuebles24,El Salto,venta-r,Desarrollo vertical,https://www.inmuebles24.com/desarrollo-vertical-en-venta-en-el-salto-q-remate.html
+Inmuebles24,Tlajomulco de Zuñiga,venta-r,Desarrollo vertical,https://www.inmuebles24.com/desarrollo-vertical-en-venta-en-tlajomulco-de-zuniga-q-remate.html
+Inmuebles24,Zapopan,venta-r,Edificio,https://www.inmuebles24.com/edificio-en-venta-en-zapopan-q-remate.html
+Inmuebles24,Guadalajara,venta-r,Edificio,https://www.inmuebles24.com/edificio-en-venta-en-guadalajara-q-remate.html
+Inmuebles24,San Pedro Tlaquepaque,venta-r,Edificio,https://www.inmuebles24.com/edificio-en-venta-en-san-pedro-tlaquepaque-q-remate.html
+Inmuebles24,Tonalá,venta-r,Edificio,https://www.inmuebles24.com/edificio-en-venta-en-tonala-q-remate.html
+Inmuebles24,Zapotlanejo,venta-r,Edificio,https://www.inmuebles24.com/edificio-en-venta-en-zapotlanejo-q-remate.html
+Inmuebles24,Juanacatlán,venta-r,Edificio,https://www.inmuebles24.com/edificio-en-venta-en-juanacatlan-q-remate.html
+Inmuebles24,Ixtlahuacán de los Membrillos,venta-r,Edificio,https://www.inmuebles24.com/edificio-en-venta-en-ixtlahuacan-de-los-membrillos-q-remate.html
+Inmuebles24,El Salto,venta-r,Edificio,https://www.inmuebles24.com/edificio-en-venta-en-el-salto-q-remate.html
+Inmuebles24,Tlajomulco de Zuñiga,venta-r,Edificio,https://www.inmuebles24.com/edificio-en-venta-en-tlajomulco-de-zuniga-q-remate.html
+Inmuebles24,Zapopan,venta-r,Huerta,https://www.inmuebles24.com/huerta-en-venta-en-zapopan-q-remate.html
+Inmuebles24,Guadalajara,venta-r,Huerta,https://www.inmuebles24.com/huerta-en-venta-en-guadalajara-q-remate.html
+Inmuebles24,San Pedro Tlaquepaque,venta-r,Huerta,https://www.inmuebles24.com/huerta-en-venta-en-san-pedro-tlaquepaque-q-remate.html
+Inmuebles24,Tonalá,venta-r,Huerta,https://www.inmuebles24.com/huerta-en-venta-en-tonala-q-remate.html
+Inmuebles24,Zapotlanejo,venta-r,Huerta,https://www.inmuebles24.com/huerta-en-venta-en-zapotlanejo-q-remate.html
+Inmuebles24,Juanacatlán,venta-r,Huerta,https://www.inmuebles24.com/huerta-en-venta-en-juanacatlan-q-remate.html
+Inmuebles24,Ixtlahuacán de los Membrillos,venta-r,Huerta,https://www.inmuebles24.com/huerta-en-venta-en-ixtlahuacan-de-los-membrillos-q-remate.html
+Inmuebles24,El Salto,venta-r,Huerta,https://www.inmuebles24.com/huerta-en-venta-en-el-salto-q-remate.html
+Inmuebles24,Tlajomulco de Zuñiga,venta-r,Huerta,https://www.inmuebles24.com/huerta-en-venta-en-tlajomulco-de-zuniga-q-remate.html
+Inmuebles24,Zapopan,venta-r,Inmueble productivo urbano,https://www.inmuebles24.com/inmueble-productivo-urbano-en-venta-en-zapopan-q-remate.html
+Inmuebles24,Guadalajara,venta-r,Inmueble productivo urbano,https://www.inmuebles24.com/inmueble-productivo-urbano-en-venta-en-guadalajara-q-remate.html
+Inmuebles24,San Pedro Tlaquepaque,venta-r,Inmueble productivo urbano,https://www.inmuebles24.com/inmueble-productivo-urbano-en-venta-en-san-pedro-tlaquepaque-q-remate.html
+Inmuebles24,Tonalá,venta-r,Inmueble productivo urbano,https://www.inmuebles24.com/inmueble-productivo-urbano-en-venta-en-tonala-q-remate.html
+Inmuebles24,Zapotlanejo,venta-r,Inmueble productivo urbano,https://www.inmuebles24.com/inmueble-productivo-urbano-en-venta-en-zapotlanejo-q-remate.html
+Inmuebles24,Juanacatlán,venta-r,Inmueble productivo urbano,https://www.inmuebles24.com/inmueble-productivo-urbano-en-venta-en-juanacatlan-q-remate.html
+Inmuebles24,Ixtlahuacán de los Membrillos,venta-r,Inmueble productivo urbano,https://www.inmuebles24.com/inmueble-productivo-urbano-en-venta-en-ixtlahuacan-de-los-membrillos-q-remate.html
+Inmuebles24,El Salto,venta-r,Inmueble productivo urbano,https://www.inmuebles24.com/inmueble-productivo-urbano-en-venta-en-el-salto-q-remate.html
+Inmuebles24,Tlajomulco de Zuñiga,venta-r,Inmueble productivo urbano,https://www.inmuebles24.com/inmueble-productivo-urbano-en-venta-en-tlajomulco-de-zuniga-q-remate.html
+Inmuebles24,Zapopan,venta-r,Local en centro comercial,https://www.inmuebles24.com/local-en-centro-comercial-en-venta-en-zapopan-q-remate.html
+Inmuebles24,Guadalajara,venta-r,Local en centro comercial,https://www.inmuebles24.com/local-en-centro-comercial-en-venta-en-guadalajara-q-remate.html
+Inmuebles24,San Pedro Tlaquepaque,venta-r,Local en centro comercial,https://www.inmuebles24.com/local-en-centro-comercial-en-venta-en-san-pedro-tlaquepaque-q-remate.html
+Inmuebles24,Tonalá,venta-r,Local en centro comercial,https://www.inmuebles24.com/local-en-centro-comercial-en-venta-en-tonala-q-remate.html
+Inmuebles24,Zapotlanejo,venta-r,Local en centro comercial,https://www.inmuebles24.com/local-en-centro-comercial-en-venta-en-zapotlanejo-q-remate.html
+Inmuebles24,Juanacatlán,venta-r,Local en centro comercial,https://www.inmuebles24.com/local-en-centro-comercial-en-venta-en-juanacatlan-q-remate.html
+Inmuebles24,Ixtlahuacán de los Membrillos,venta-r,Local en centro comercial,https://www.inmuebles24.com/local-en-centro-comercial-en-venta-en-ixtlahuacan-de-los-membrillos-q-remate.html
+Inmuebles24,El Salto,venta-r,Local en centro comercial,https://www.inmuebles24.com/local-en-centro-comercial-en-venta-en-el-salto-q-remate.html
+Inmuebles24,Tlajomulco de Zuñiga,venta-r,Local en centro comercial,https://www.inmuebles24.com/local-en-centro-comercial-en-venta-en-tlajomulco-de-zuniga-q-remate.html
+Inmuebles24,Zapopan,venta-r,Locales comerciales,https://www.inmuebles24.com/locales-comerciales-en-venta-en-zapopan-q-remate.html
+Inmuebles24,Guadalajara,venta-r,Locales comerciales,https://www.inmuebles24.com/locales-comerciales-en-venta-en-guadalajara-q-remate.html
+Inmuebles24,San Pedro Tlaquepaque,venta-r,Locales comerciales,https://www.inmuebles24.com/locales-comerciales-en-venta-en-san-pedro-tlaquepaque-q-remate.html
+Inmuebles24,Tonalá,venta-r,Locales comerciales,https://www.inmuebles24.com/locales-comerciales-en-venta-en-tonala-q-remate.html
+Inmuebles24,Zapotlanejo,venta-r,Locales comerciales,https://www.inmuebles24.com/locales-comerciales-en-venta-en-zapotlanejo-q-remate.html
+Inmuebles24,Juanacatlán,venta-r,Locales comerciales,https://www.inmuebles24.com/locales-comerciales-en-venta-en-juanacatlan-q-remate.html
+Inmuebles24,Ixtlahuacán de los Membrillos,venta-r,Locales comerciales,https://www.inmuebles24.com/locales-comerciales-en-venta-en-ixtlahuacan-de-los-membrillos-q-remate.html
+Inmuebles24,El Salto,venta-r,Locales comerciales,https://www.inmuebles24.com/locales-comerciales-en-venta-en-el-salto-q-remate.html
+Inmuebles24,Tlajomulco de Zuñiga,venta-r,Locales comerciales,https://www.inmuebles24.com/locales-comerciales-en-venta-en-tlajomulco-de-zuniga-q-remate.html
+Inmuebles24,Zapopan,venta-r,Nave industrial,https://www.inmuebles24.com/nave-industrial-en-venta-en-zapopan-q-remate.html
+Inmuebles24,Guadalajara,venta-r,Nave industrial,https://www.inmuebles24.com/nave-industrial-en-venta-en-guadalajara-q-remate.html
+Inmuebles24,San Pedro Tlaquepaque,venta-r,Nave industrial,https://www.inmuebles24.com/nave-industrial-en-venta-en-san-pedro-tlaquepaque-q-remate.html
+Inmuebles24,Tonalá,venta-r,Nave industrial,https://www.inmuebles24.com/nave-industrial-en-venta-en-tonala-q-remate.html
+Inmuebles24,Zapotlanejo,venta-r,Nave industrial,https://www.inmuebles24.com/nave-industrial-en-venta-en-zapotlanejo-q-remate.html
+Inmuebles24,Juanacatlán,venta-r,Nave industrial,https://www.inmuebles24.com/nave-industrial-en-venta-en-juanacatlan-q-remate.html
+Inmuebles24,Ixtlahuacán de los Membrillos,venta-r,Nave industrial,https://www.inmuebles24.com/nave-industrial-en-venta-en-ixtlahuacan-de-los-membrillos-q-remate.html
+Inmuebles24,El Salto,venta-r,Nave industrial,https://www.inmuebles24.com/nave-industrial-en-venta-en-el-salto-q-remate.html
+Inmuebles24,Tlajomulco de Zuñiga,venta-r,Nave industrial,https://www.inmuebles24.com/nave-industrial-en-venta-en-tlajomulco-de-zuniga-q-remate.html
+Inmuebles24,Zapopan,venta-r,Oficinas,https://www.inmuebles24.com/oficinas-en-venta-en-zapopan-q-remate.html
+Inmuebles24,Guadalajara,venta-r,Oficinas,https://www.inmuebles24.com/oficinas-en-venta-en-guadalajara-q-remate.html
+Inmuebles24,San Pedro Tlaquepaque,venta-r,Oficinas,https://www.inmuebles24.com/oficinas-en-venta-en-san-pedro-tlaquepaque-q-remate.html
+Inmuebles24,Tonalá,venta-r,Oficinas,https://www.inmuebles24.com/oficinas-en-venta-en-tonala-q-remate.html
+Inmuebles24,Zapotlanejo,venta-r,Oficinas,https://www.inmuebles24.com/oficinas-en-venta-en-zapotlanejo-q-remate.html
+Inmuebles24,Juanacatlán,venta-r,Oficinas,https://www.inmuebles24.com/oficinas-en-venta-en-juanacatlan-q-remate.html
+Inmuebles24,Ixtlahuacán de los Membrillos,venta-r,Oficinas,https://www.inmuebles24.com/oficinas-en-venta-en-ixtlahuacan-de-los-membrillos-q-remate.html
+Inmuebles24,El Salto,venta-r,Oficinas,https://www.inmuebles24.com/oficinas-en-venta-en-el-salto-q-remate.html
+Inmuebles24,Tlajomulco de Zuñiga,venta-r,Oficinas,https://www.inmuebles24.com/oficinas-en-venta-en-tlajomulco-de-zuniga-q-remate.html
+Inmuebles24,Zapopan,venta-r,Quinta,https://www.inmuebles24.com/quinta-en-venta-en-zapopan-q-remate.html
+Inmuebles24,Guadalajara,venta-r,Quinta,https://www.inmuebles24.com/quinta-en-venta-en-guadalajara-q-remate.html
+Inmuebles24,San Pedro Tlaquepaque,venta-r,Quinta,https://www.inmuebles24.com/quinta-en-venta-en-san-pedro-tlaquepaque-q-remate.html
+Inmuebles24,Tonalá,venta-r,Quinta,https://www.inmuebles24.com/quinta-en-venta-en-tonala-q-remate.html
+Inmuebles24,Zapotlanejo,venta-r,Quinta,https://www.inmuebles24.com/quinta-en-venta-en-zapotlanejo-q-remate.html
+Inmuebles24,Juanacatlán,venta-r,Quinta,https://www.inmuebles24.com/quinta-en-venta-en-juanacatlan-q-remate.html
+Inmuebles24,Ixtlahuacán de los Membrillos,venta-r,Quinta,https://www.inmuebles24.com/quinta-en-venta-en-ixtlahuacan-de-los-membrillos-q-remate.html
+Inmuebles24,El Salto,venta-r,Quinta,https://www.inmuebles24.com/quinta-en-venta-en-el-salto-q-remate.html
+Inmuebles24,Tlajomulco de Zuñiga,venta-r,Quinta,https://www.inmuebles24.com/quinta-en-venta-en-tlajomulco-de-zuniga-q-remate.html
+Inmuebles24,Zapopan,venta-r,Terreno comercial,https://www.inmuebles24.com/terreno-comercial-en-venta-en-zapopan-q-remate.html
+Inmuebles24,Guadalajara,venta-r,Terreno comercial,https://www.inmuebles24.com/terreno-comercial-en-venta-en-guadalajara-q-remate.html
+Inmuebles24,San Pedro Tlaquepaque,venta-r,Terreno comercial,https://www.inmuebles24.com/terreno-comercial-en-venta-en-san-pedro-tlaquepaque-q-remate.html
+Inmuebles24,Tonalá,venta-r,Terreno comercial,https://www.inmuebles24.com/terreno-comercial-en-venta-en-tonala-q-remate.html
+Inmuebles24,Zapotlanejo,venta-r,Terreno comercial,https://www.inmuebles24.com/terreno-comercial-en-venta-en-zapotlanejo-q-remate.html
+Inmuebles24,Juanacatlán,venta-r,Terreno comercial,https://www.inmuebles24.com/terreno-comercial-en-venta-en-juanacatlan-q-remate.html
+Inmuebles24,Ixtlahuacán de los Membrillos,venta-r,Terreno comercial,https://www.inmuebles24.com/terreno-comercial-en-venta-en-ixtlahuacan-de-los-membrillos-q-remate.html
+Inmuebles24,El Salto,venta-r,Terreno comercial,https://www.inmuebles24.com/terreno-comercial-en-venta-en-el-salto-q-remate.html
+Inmuebles24,Tlajomulco de Zuñiga,venta-r,Terreno comercial,https://www.inmuebles24.com/terreno-comercial-en-venta-en-tlajomulco-de-zuniga-q-remate.html
+Inmuebles24,Zapopan,venta-r,Terreno industrial,https://www.inmuebles24.com/terreno-industrial-en-venta-en-zapopan-q-remate.html
+Inmuebles24,Guadalajara,venta-r,Terreno industrial,https://www.inmuebles24.com/terreno-industrial-en-venta-en-guadalajara-q-remate.html
+Inmuebles24,San Pedro Tlaquepaque,venta-r,Terreno industrial,https://www.inmuebles24.com/terreno-industrial-en-venta-en-san-pedro-tlaquepaque-q-remate.html
+Inmuebles24,Tonalá,venta-r,Terreno industrial,https://www.inmuebles24.com/terreno-industrial-en-venta-en-tonala-q-remate.html
+Inmuebles24,Zapotlanejo,venta-r,Terreno industrial,https://www.inmuebles24.com/terreno-industrial-en-venta-en-zapotlanejo-q-remate.html
+Inmuebles24,Juanacatlán,venta-r,Terreno industrial,https://www.inmuebles24.com/terreno-industrial-en-venta-en-juanacatlan-q-remate.html
+Inmuebles24,Ixtlahuacán de los Membrillos,venta-r,Terreno industrial,https://www.inmuebles24.com/terreno-industrial-en-venta-en-ixtlahuacan-de-los-membrillos-q-remate.html
+Inmuebles24,El Salto,venta-r,Terreno industrial,https://www.inmuebles24.com/terreno-industrial-en-venta-en-el-salto-q-remate.html
+Inmuebles24,Tlajomulco de Zuñiga,venta-r,Terreno industrial,https://www.inmuebles24.com/terreno-industrial-en-venta-en-tlajomulco-de-zuniga-q-remate.html
+Inmuebles24,Zapopan,venta-r,Terrenos,https://www.inmuebles24.com/terrenos-en-venta-en-zapopan-q-remate.html
+Inmuebles24,Guadalajara,venta-r,Terrenos,https://www.inmuebles24.com/terrenos-en-venta-en-guadalajara-q-remate.html
+Inmuebles24,San Pedro Tlaquepaque,venta-r,Terrenos,https://www.inmuebles24.com/terrenos-en-venta-en-san-pedro-tlaquepaque-q-remate.html
+Inmuebles24,Tonalá,venta-r,Terrenos,https://www.inmuebles24.com/terrenos-en-venta-en-tonala-q-remate.html
+Inmuebles24,Zapotlanejo,venta-r,Terrenos,https://www.inmuebles24.com/terrenos-en-venta-en-zapotlanejo-q-remate.html
+Inmuebles24,Juanacatlán,venta-r,Terrenos,https://www.inmuebles24.com/terrenos-en-venta-en-juanacatlan-q-remate.html
+Inmuebles24,Ixtlahuacán de los Membrillos,venta-r,Terrenos,https://www.inmuebles24.com/terrenos-en-venta-en-ixtlahuacan-de-los-membrillos-q-remate.html
+Inmuebles24,El Salto,venta-r,Terrenos,https://www.inmuebles24.com/terrenos-en-venta-en-el-salto-q-remate.html
+Inmuebles24,Tlajomulco de Zuñiga,venta-r,Terrenos,https://www.inmuebles24.com/terrenos-en-venta-en-tlajomulco-de-zuniga-q-remate.html
+Inmuebles24,Zapopan,venta-r,Villa,https://www.inmuebles24.com/villa-en-venta-en-zapopan-q-remate.html
+Inmuebles24,Guadalajara,venta-r,Villa,https://www.inmuebles24.com/villa-en-venta-en-guadalajara-q-remate.html
+Inmuebles24,San Pedro Tlaquepaque,venta-r,Villa,https://www.inmuebles24.com/villa-en-venta-en-san-pedro-tlaquepaque-q-remate.html
+Inmuebles24,Tonalá,venta-r,Villa,https://www.inmuebles24.com/villa-en-venta-en-tonala-q-remate.html
+Inmuebles24,Zapotlanejo,venta-r,Villa,https://www.inmuebles24.com/villa-en-venta-en-zapotlanejo-q-remate.html
+Inmuebles24,Juanacatlán,venta-r,Villa,https://www.inmuebles24.com/villa-en-venta-en-juanacatlan-q-remate.html
+Inmuebles24,Ixtlahuacán de los Membrillos,venta-r,Villa,https://www.inmuebles24.com/villa-en-venta-en-ixtlahuacan-de-los-membrillos-q-remate.html
+Inmuebles24,El Salto,venta-r,Villa,https://www.inmuebles24.com/villa-en-venta-en-el-salto-q-remate.html
+Inmuebles24,Tlajomulco de Zuñiga,venta-r,Villa,https://www.inmuebles24.com/villa-en-venta-en-tlajomulco-de-zuniga-q-remate.html
+Inmuebles24,Zapopan,renta,Bodegas comerciales,https://www.inmuebles24.com/bodegas-comerciales-en-renta-en-zapopan.html
+Inmuebles24,Guadalajara,renta,Bodegas comerciales,https://www.inmuebles24.com/bodegas-comerciales-en-renta-en-guadalajara.html
+Inmuebles24,San Pedro Tlaquepaque,renta,Bodegas comerciales,https://www.inmuebles24.com/bodegas-comerciales-en-renta-en-san-pedro-tlaquepaque.html
+Inmuebles24,Tonalá,renta,Bodegas comerciales,https://www.inmuebles24.com/bodegas-comerciales-en-renta-en-tonala.html
+Inmuebles24,Zapotlanejo,renta,Bodegas comerciales,https://www.inmuebles24.com/bodegas-comerciales-en-renta-en-zapotlanejo.html
+Inmuebles24,Juanacatlán,renta,Bodegas comerciales,https://www.inmuebles24.com/bodegas-comerciales-en-renta-en-juanacatlan.html
+Inmuebles24,Ixtlahuacán de los Membrillos,renta,Bodegas comerciales,https://www.inmuebles24.com/bodegas-comerciales-en-renta-en-ixtlahuacan-de-los-membrillos.html
+Inmuebles24,El Salto,renta,Bodegas comerciales,https://www.inmuebles24.com/bodegas-comerciales-en-renta-en-el-salto.html
+Inmuebles24,Tlajomulco de Zuñiga,renta,Bodegas comerciales,https://www.inmuebles24.com/bodegas-comerciales-en-renta-en-tlajomulco-de-zuniga.html
+Inmuebles24,Zapopan,renta,Casa en condominio,https://www.inmuebles24.com/casa-en-condominio-en-renta-en-zapopan.html
+Inmuebles24,Guadalajara,renta,Casa en condominio,https://www.inmuebles24.com/casa-en-condominio-en-renta-en-guadalajara.html
+Inmuebles24,San Pedro Tlaquepaque,renta,Casa en condominio,https://www.inmuebles24.com/casa-en-condominio-en-renta-en-san-pedro-tlaquepaque.html
+Inmuebles24,Tonalá,renta,Casa en condominio,https://www.inmuebles24.com/casa-en-condominio-en-renta-en-tonala.html
+Inmuebles24,Zapotlanejo,renta,Casa en condominio,https://www.inmuebles24.com/casa-en-condominio-en-renta-en-zapotlanejo.html
+Inmuebles24,Juanacatlán,renta,Casa en condominio,https://www.inmuebles24.com/casa-en-condominio-en-renta-en-juanacatlan.html
+Inmuebles24,Ixtlahuacán de los Membrillos,renta,Casa en condominio,https://www.inmuebles24.com/casa-en-condominio-en-renta-en-ixtlahuacan-de-los-membrillos.html
+Inmuebles24,El Salto,renta,Casa en condominio,https://www.inmuebles24.com/casa-en-condominio-en-renta-en-el-salto.html
+Inmuebles24,Tlajomulco de Zuñiga,renta,Casa en condominio,https://www.inmuebles24.com/casa-en-condominio-en-renta-en-tlajomulco-de-zuniga.html
+Inmuebles24,Zapopan,renta,Casa uso de suelo,https://www.inmuebles24.com/casa-uso-de-suelo-en-renta-en-zapopan.html
+Inmuebles24,Guadalajara,renta,Casa uso de suelo,https://www.inmuebles24.com/casa-uso-de-suelo-en-renta-en-guadalajara.html
+Inmuebles24,San Pedro Tlaquepaque,renta,Casa uso de suelo,https://www.inmuebles24.com/casa-uso-de-suelo-en-renta-en-san-pedro-tlaquepaque.html
+Inmuebles24,Tonalá,renta,Casa uso de suelo,https://www.inmuebles24.com/casa-uso-de-suelo-en-renta-en-tonala.html
+Inmuebles24,Zapotlanejo,renta,Casa uso de suelo,https://www.inmuebles24.com/casa-uso-de-suelo-en-renta-en-zapotlanejo.html
+Inmuebles24,Juanacatlán,renta,Casa uso de suelo,https://www.inmuebles24.com/casa-uso-de-suelo-en-renta-en-juanacatlan.html
+Inmuebles24,Ixtlahuacán de los Membrillos,renta,Casa uso de suelo,https://www.inmuebles24.com/casa-uso-de-suelo-en-renta-en-ixtlahuacan-de-los-membrillos.html
+Inmuebles24,El Salto,renta,Casa uso de suelo,https://www.inmuebles24.com/casa-uso-de-suelo-en-renta-en-el-salto.html
+Inmuebles24,Tlajomulco de Zuñiga,renta,Casa uso de suelo,https://www.inmuebles24.com/casa-uso-de-suelo-en-renta-en-tlajomulco-de-zuniga.html
+Inmuebles24,Zapopan,renta,Casas,https://www.inmuebles24.com/casas-en-renta-en-zapopan.html
+Inmuebles24,Guadalajara,renta,Casas,https://www.inmuebles24.com/casas-en-renta-en-guadalajara.html
+Inmuebles24,San Pedro Tlaquepaque,renta,Casas,https://www.inmuebles24.com/casas-en-renta-en-san-pedro-tlaquepaque.html
+Inmuebles24,Tonalá,renta,Casas,https://www.inmuebles24.com/casas-en-renta-en-tonala.html
+Inmuebles24,Zapotlanejo,renta,Casas,https://www.inmuebles24.com/casas-en-renta-en-zapotlanejo.html
+Inmuebles24,Juanacatlán,renta,Casas,https://www.inmuebles24.com/casas-en-renta-en-juanacatlan.html
+Inmuebles24,Ixtlahuacán de los Membrillos,renta,Casas,https://www.inmuebles24.com/casas-en-renta-en-ixtlahuacan-de-los-membrillos.html
+Inmuebles24,El Salto,renta,Casas,https://www.inmuebles24.com/casas-en-renta-en-el-salto.html
+Inmuebles24,Tlajomulco de Zuñiga,renta,Casas,https://www.inmuebles24.com/casas-en-renta-en-tlajomulco-de-zuniga.html
+Inmuebles24,Zapopan,renta,Dúplex,https://www.inmuebles24.com/duplex-en-renta-en-zapopan.html
+Inmuebles24,Guadalajara,renta,Dúplex,https://www.inmuebles24.com/duplex-en-renta-en-guadalajara.html
+Inmuebles24,San Pedro Tlaquepaque,renta,Dúplex,https://www.inmuebles24.com/duplex-en-renta-en-san-pedro-tlaquepaque.html
+Inmuebles24,Tonalá,renta,Dúplex,https://www.inmuebles24.com/duplex-en-renta-en-tonala.html
+Inmuebles24,Zapotlanejo,renta,Dúplex,https://www.inmuebles24.com/duplex-en-renta-en-zapotlanejo.html
+Inmuebles24,Juanacatlán,renta,Dúplex,https://www.inmuebles24.com/duplex-en-renta-en-juanacatlan.html
+Inmuebles24,Ixtlahuacán de los Membrillos,renta,Dúplex,https://www.inmuebles24.com/duplex-en-renta-en-ixtlahuacan-de-los-membrillos.html
+Inmuebles24,El Salto,renta,Dúplex,https://www.inmuebles24.com/duplex-en-renta-en-el-salto.html
+Inmuebles24,Tlajomulco de Zuñiga,renta,Dúplex,https://www.inmuebles24.com/duplex-en-renta-en-tlajomulco-de-zuniga.html
+Inmuebles24,Zapopan,renta,Departamento compartido,https://www.inmuebles24.com/departamento-compartido-en-renta-en-zapopan.html
+Inmuebles24,Guadalajara,renta,Departamento compartido,https://www.inmuebles24.com/departamento-compartido-en-renta-en-guadalajara.html
+Inmuebles24,San Pedro Tlaquepaque,renta,Departamento compartido,https://www.inmuebles24.com/departamento-compartido-en-renta-en-san-pedro-tlaquepaque.html
+Inmuebles24,Tonalá,renta,Departamento compartido,https://www.inmuebles24.com/departamento-compartido-en-renta-en-tonala.html
+Inmuebles24,Zapotlanejo,renta,Departamento compartido,https://www.inmuebles24.com/departamento-compartido-en-renta-en-zapotlanejo.html
+Inmuebles24,Juanacatlán,renta,Departamento compartido,https://www.inmuebles24.com/departamento-compartido-en-renta-en-juanacatlan.html
+Inmuebles24,Ixtlahuacán de los Membrillos,renta,Departamento compartido,https://www.inmuebles24.com/departamento-compartido-en-renta-en-ixtlahuacan-de-los-membrillos.html
+Inmuebles24,El Salto,renta,Departamento compartido,https://www.inmuebles24.com/departamento-compartido-en-renta-en-el-salto.html
+Inmuebles24,Tlajomulco de Zuñiga,renta,Departamento compartido,https://www.inmuebles24.com/departamento-compartido-en-renta-en-tlajomulco-de-zuniga.html
+Inmuebles24,Zapopan,renta,Departamentos,https://www.inmuebles24.com/departamentos-en-renta-en-zapopan.html
+Inmuebles24,Guadalajara,renta,Departamentos,https://www.inmuebles24.com/departamentos-en-renta-en-guadalajara.html
+Inmuebles24,San Pedro Tlaquepaque,renta,Departamentos,https://www.inmuebles24.com/departamentos-en-renta-en-san-pedro-tlaquepaque.html
+Inmuebles24,Tonalá,renta,Departamentos,https://www.inmuebles24.com/departamentos-en-renta-en-tonala.html
+Inmuebles24,Zapotlanejo,renta,Departamentos,https://www.inmuebles24.com/departamentos-en-renta-en-zapotlanejo.html
+Inmuebles24,Juanacatlán,renta,Departamentos,https://www.inmuebles24.com/departamentos-en-renta-en-juanacatlan.html
+Inmuebles24,Ixtlahuacán de los Membrillos,renta,Departamentos,https://www.inmuebles24.com/departamentos-en-renta-en-ixtlahuacan-de-los-membrillos.html
+Inmuebles24,El Salto,renta,Departamentos,https://www.inmuebles24.com/departamentos-en-renta-en-el-salto.html
+Inmuebles24,Tlajomulco de Zuñiga,renta,Departamentos,https://www.inmuebles24.com/departamentos-en-renta-en-tlajomulco-de-zuniga.html
+Inmuebles24,Zapopan,venta-d,Desarrollo horizontal,https://www.inmuebles24.com/desarrollo-horizontal-en-renta-en-zapopan.html
+Inmuebles24,Guadalajara,venta-d,Desarrollo horizontal,https://www.inmuebles24.com/desarrollo-horizontal-en-renta-en-guadalajara.html
+Inmuebles24,San Pedro Tlaquepaque,venta-d,Desarrollo horizontal,https://www.inmuebles24.com/desarrollo-horizontal-en-renta-en-san-pedro-tlaquepaque.html
+Inmuebles24,Tonalá,venta-d,Desarrollo horizontal,https://www.inmuebles24.com/desarrollo-horizontal-en-renta-en-tonala.html
+Inmuebles24,Zapotlanejo,venta-d,Desarrollo horizontal,https://www.inmuebles24.com/desarrollo-horizontal-en-renta-en-zapotlanejo.html
+Inmuebles24,Juanacatlán,venta-d,Desarrollo horizontal,https://www.inmuebles24.com/desarrollo-horizontal-en-renta-en-juanacatlan.html
+Inmuebles24,Ixtlahuacán de los Membrillos,venta-d,Desarrollo horizontal,https://www.inmuebles24.com/desarrollo-horizontal-en-renta-en-ixtlahuacan-de-los-membrillos.html
+Inmuebles24,El Salto,venta-d,Desarrollo horizontal,https://www.inmuebles24.com/desarrollo-horizontal-en-renta-en-el-salto.html
+Inmuebles24,Tlajomulco de Zuñiga,venta-d,Desarrollo horizontal,https://www.inmuebles24.com/desarrollo-horizontal-en-renta-en-tlajomulco-de-zuniga.html
+Inmuebles24,Zapopan,venta-d,Desarrollo horizontal/vertical,https://www.inmuebles24.com/desarrollo-horizontal-vertical-en-renta-en-zapopan.html
+Inmuebles24,Guadalajara,venta-d,Desarrollo horizontal/vertical,https://www.inmuebles24.com/desarrollo-horizontal-vertical-en-renta-en-guadalajara.html
+Inmuebles24,San Pedro Tlaquepaque,venta-d,Desarrollo horizontal/vertical,https://www.inmuebles24.com/desarrollo-horizontal-vertical-en-renta-en-san-pedro-tlaquepaque.html
+Inmuebles24,Tonalá,venta-d,Desarrollo horizontal/vertical,https://www.inmuebles24.com/desarrollo-horizontal-vertical-en-renta-en-tonala.html
+Inmuebles24,Zapotlanejo,venta-d,Desarrollo horizontal/vertical,https://www.inmuebles24.com/desarrollo-horizontal-vertical-en-renta-en-zapotlanejo.html
+Inmuebles24,Juanacatlán,venta-d,Desarrollo horizontal/vertical,https://www.inmuebles24.com/desarrollo-horizontal-vertical-en-renta-en-juanacatlan.html
+Inmuebles24,Ixtlahuacán de los Membrillos,venta-d,Desarrollo horizontal/vertical,https://www.inmuebles24.com/desarrollo-horizontal-vertical-en-renta-en-ixtlahuacan-de-los-membrillos.html
+Inmuebles24,El Salto,venta-d,Desarrollo horizontal/vertical,https://www.inmuebles24.com/desarrollo-horizontal-vertical-en-renta-en-el-salto.html
+Inmuebles24,Tlajomulco de Zuñiga,venta-d,Desarrollo horizontal/vertical,https://www.inmuebles24.com/desarrollo-horizontal-vertical-en-renta-en-tlajomulco-de-zuniga.html
+Inmuebles24,Zapopan,renta,Desarrollo vertical,https://www.inmuebles24.com/desarrollo-vertical-en-renta-en-zapopan.html
+Inmuebles24,Guadalajara,renta,Desarrollo vertical,https://www.inmuebles24.com/desarrollo-vertical-en-renta-en-guadalajara.html
+Inmuebles24,San Pedro Tlaquepaque,renta,Desarrollo vertical,https://www.inmuebles24.com/desarrollo-vertical-en-renta-en-san-pedro-tlaquepaque.html
+Inmuebles24,Tonalá,renta,Desarrollo vertical,https://www.inmuebles24.com/desarrollo-vertical-en-renta-en-tonala.html
+Inmuebles24,Zapotlanejo,renta,Desarrollo vertical,https://www.inmuebles24.com/desarrollo-vertical-en-renta-en-zapotlanejo.html
+Inmuebles24,Juanacatlán,renta,Desarrollo vertical,https://www.inmuebles24.com/desarrollo-vertical-en-renta-en-juanacatlan.html
+Inmuebles24,Ixtlahuacán de los Membrillos,renta,Desarrollo vertical,https://www.inmuebles24.com/desarrollo-vertical-en-renta-en-ixtlahuacan-de-los-membrillos.html
+Inmuebles24,El Salto,renta,Desarrollo vertical,https://www.inmuebles24.com/desarrollo-vertical-en-renta-en-el-salto.html
+Inmuebles24,Tlajomulco de Zuñiga,renta,Desarrollo vertical,https://www.inmuebles24.com/desarrollo-vertical-en-renta-en-tlajomulco-de-zuniga.html
+Inmuebles24,Zapopan,renta,Edificio,https://www.inmuebles24.com/edificio-en-renta-en-zapopan.html
+Inmuebles24,Guadalajara,renta,Edificio,https://www.inmuebles24.com/edificio-en-renta-en-guadalajara.html
+Inmuebles24,San Pedro Tlaquepaque,renta,Edificio,https://www.inmuebles24.com/edificio-en-renta-en-san-pedro-tlaquepaque.html
+Inmuebles24,Tonalá,renta,Edificio,https://www.inmuebles24.com/edificio-en-renta-en-tonala.html
+Inmuebles24,Zapotlanejo,renta,Edificio,https://www.inmuebles24.com/edificio-en-renta-en-zapotlanejo.html
+Inmuebles24,Juanacatlán,renta,Edificio,https://www.inmuebles24.com/edificio-en-renta-en-juanacatlan.html
+Inmuebles24,Ixtlahuacán de los Membrillos,renta,Edificio,https://www.inmuebles24.com/edificio-en-renta-en-ixtlahuacan-de-los-membrillos.html
+Inmuebles24,El Salto,renta,Edificio,https://www.inmuebles24.com/edificio-en-renta-en-el-salto.html
+Inmuebles24,Tlajomulco de Zuñiga,renta,Edificio,https://www.inmuebles24.com/edificio-en-renta-en-tlajomulco-de-zuniga.html
+Inmuebles24,Zapopan,renta,Huerta,https://www.inmuebles24.com/huerta-en-renta-en-zapopan.html
+Inmuebles24,Guadalajara,renta,Huerta,https://www.inmuebles24.com/huerta-en-renta-en-guadalajara.html
+Inmuebles24,San Pedro Tlaquepaque,renta,Huerta,https://www.inmuebles24.com/huerta-en-renta-en-san-pedro-tlaquepaque.html
+Inmuebles24,Tonalá,renta,Huerta,https://www.inmuebles24.com/huerta-en-renta-en-tonala.html
+Inmuebles24,Zapotlanejo,renta,Huerta,https://www.inmuebles24.com/huerta-en-renta-en-zapotlanejo.html
+Inmuebles24,Juanacatlán,renta,Huerta,https://www.inmuebles24.com/huerta-en-renta-en-juanacatlan.html
+Inmuebles24,Ixtlahuacán de los Membrillos,renta,Huerta,https://www.inmuebles24.com/huerta-en-renta-en-ixtlahuacan-de-los-membrillos.html
+Inmuebles24,El Salto,renta,Huerta,https://www.inmuebles24.com/huerta-en-renta-en-el-salto.html
+Inmuebles24,Tlajomulco de Zuñiga,renta,Huerta,https://www.inmuebles24.com/huerta-en-renta-en-tlajomulco-de-zuniga.html
+Inmuebles24,Zapopan,renta,Inmueble productivo urbano,https://www.inmuebles24.com/inmueble-productivo-urbano-en-renta-en-zapopan.html
+Inmuebles24,Guadalajara,renta,Inmueble productivo urbano,https://www.inmuebles24.com/inmueble-productivo-urbano-en-renta-en-guadalajara.html
+Inmuebles24,San Pedro Tlaquepaque,renta,Inmueble productivo urbano,https://www.inmuebles24.com/inmueble-productivo-urbano-en-renta-en-san-pedro-tlaquepaque.html
+Inmuebles24,Tonalá,renta,Inmueble productivo urbano,https://www.inmuebles24.com/inmueble-productivo-urbano-en-renta-en-tonala.html
+Inmuebles24,Zapotlanejo,renta,Inmueble productivo urbano,https://www.inmuebles24.com/inmueble-productivo-urbano-en-renta-en-zapotlanejo.html
+Inmuebles24,Juanacatlán,renta,Inmueble productivo urbano,https://www.inmuebles24.com/inmueble-productivo-urbano-en-renta-en-juanacatlan.html
+Inmuebles24,Ixtlahuacán de los Membrillos,renta,Inmueble productivo urbano,https://www.inmuebles24.com/inmueble-productivo-urbano-en-renta-en-ixtlahuacan-de-los-membrillos.html
+Inmuebles24,El Salto,renta,Inmueble productivo urbano,https://www.inmuebles24.com/inmueble-productivo-urbano-en-renta-en-el-salto.html
+Inmuebles24,Tlajomulco de Zuñiga,renta,Inmueble productivo urbano,https://www.inmuebles24.com/inmueble-productivo-urbano-en-renta-en-tlajomulco-de-zuniga.html
+Inmuebles24,Zapopan,renta,Local en centro comercial,https://www.inmuebles24.com/local-en-centro-comercial-en-renta-en-zapopan.html
+Inmuebles24,Guadalajara,renta,Local en centro comercial,https://www.inmuebles24.com/local-en-centro-comercial-en-renta-en-guadalajara.html
+Inmuebles24,San Pedro Tlaquepaque,renta,Local en centro comercial,https://www.inmuebles24.com/local-en-centro-comercial-en-renta-en-san-pedro-tlaquepaque.html
+Inmuebles24,Tonalá,renta,Local en centro comercial,https://www.inmuebles24.com/local-en-centro-comercial-en-renta-en-tonala.html
+Inmuebles24,Zapotlanejo,renta,Local en centro comercial,https://www.inmuebles24.com/local-en-centro-comercial-en-renta-en-zapotlanejo.html
+Inmuebles24,Juanacatlán,renta,Local en centro comercial,https://www.inmuebles24.com/local-en-centro-comercial-en-renta-en-juanacatlan.html
+Inmuebles24,Ixtlahuacán de los Membrillos,renta,Local en centro comercial,https://www.inmuebles24.com/local-en-centro-comercial-en-renta-en-ixtlahuacan-de-los-membrillos.html
+Inmuebles24,El Salto,renta,Local en centro comercial,https://www.inmuebles24.com/local-en-centro-comercial-en-renta-en-el-salto.html
+Inmuebles24,Tlajomulco de Zuñiga,renta,Local en centro comercial,https://www.inmuebles24.com/local-en-centro-comercial-en-renta-en-tlajomulco-de-zuniga.html
+Inmuebles24,Zapopan,renta,Locales comerciales,https://www.inmuebles24.com/locales-comerciales-en-renta-en-zapopan.html
+Inmuebles24,Guadalajara,renta,Locales comerciales,https://www.inmuebles24.com/locales-comerciales-en-renta-en-guadalajara.html
+Inmuebles24,San Pedro Tlaquepaque,renta,Locales comerciales,https://www.inmuebles24.com/locales-comerciales-en-renta-en-san-pedro-tlaquepaque.html
+Inmuebles24,Tonalá,renta,Locales comerciales,https://www.inmuebles24.com/locales-comerciales-en-renta-en-tonala.html
+Inmuebles24,Zapotlanejo,renta,Locales comerciales,https://www.inmuebles24.com/locales-comerciales-en-renta-en-zapotlanejo.html
+Inmuebles24,Juanacatlán,renta,Locales comerciales,https://www.inmuebles24.com/locales-comerciales-en-renta-en-juanacatlan.html
+Inmuebles24,Ixtlahuacán de los Membrillos,renta,Locales comerciales,https://www.inmuebles24.com/locales-comerciales-en-renta-en-ixtlahuacan-de-los-membrillos.html
+Inmuebles24,El Salto,renta,Locales comerciales,https://www.inmuebles24.com/locales-comerciales-en-renta-en-el-salto.html
+Inmuebles24,Tlajomulco de Zuñiga,renta,Locales comerciales,https://www.inmuebles24.com/locales-comerciales-en-renta-en-tlajomulco-de-zuniga.html
+Inmuebles24,Zapopan,renta,Nave industrial,https://www.inmuebles24.com/nave-industrial-en-renta-en-zapopan.html
+Inmuebles24,Guadalajara,renta,Nave industrial,https://www.inmuebles24.com/nave-industrial-en-renta-en-guadalajara.html
+Inmuebles24,San Pedro Tlaquepaque,renta,Nave industrial,https://www.inmuebles24.com/nave-industrial-en-renta-en-san-pedro-tlaquepaque.html
+Inmuebles24,Tonalá,renta,Nave industrial,https://www.inmuebles24.com/nave-industrial-en-renta-en-tonala.html
+Inmuebles24,Zapotlanejo,renta,Nave industrial,https://www.inmuebles24.com/nave-industrial-en-renta-en-zapotlanejo.html
+Inmuebles24,Juanacatlán,renta,Nave industrial,https://www.inmuebles24.com/nave-industrial-en-renta-en-juanacatlan.html
+Inmuebles24,Ixtlahuacán de los Membrillos,renta,Nave industrial,https://www.inmuebles24.com/nave-industrial-en-renta-en-ixtlahuacan-de-los-membrillos.html
+Inmuebles24,El Salto,renta,Nave industrial,https://www.inmuebles24.com/nave-industrial-en-renta-en-el-salto.html
+Inmuebles24,Tlajomulco de Zuñiga,renta,Nave industrial,https://www.inmuebles24.com/nave-industrial-en-renta-en-tlajomulco-de-zuniga.html
+Inmuebles24,Zapopan,renta,Oficinas,https://www.inmuebles24.com/oficinas-en-renta-en-zapopan.html
+Inmuebles24,Guadalajara,renta,Oficinas,https://www.inmuebles24.com/oficinas-en-renta-en-guadalajara.html
+Inmuebles24,San Pedro Tlaquepaque,renta,Oficinas,https://www.inmuebles24.com/oficinas-en-renta-en-san-pedro-tlaquepaque.html
+Inmuebles24,Tonalá,renta,Oficinas,https://www.inmuebles24.com/oficinas-en-renta-en-tonala.html
+Inmuebles24,Zapotlanejo,renta,Oficinas,https://www.inmuebles24.com/oficinas-en-renta-en-zapotlanejo.html
+Inmuebles24,Juanacatlán,renta,Oficinas,https://www.inmuebles24.com/oficinas-en-renta-en-juanacatlan.html
+Inmuebles24,Ixtlahuacán de los Membrillos,renta,Oficinas,https://www.inmuebles24.com/oficinas-en-renta-en-ixtlahuacan-de-los-membrillos.html
+Inmuebles24,El Salto,renta,Oficinas,https://www.inmuebles24.com/oficinas-en-renta-en-el-salto.html
+Inmuebles24,Tlajomulco de Zuñiga,renta,Oficinas,https://www.inmuebles24.com/oficinas-en-renta-en-tlajomulco-de-zuniga.html
+Inmuebles24,Zapopan,renta,Quinta,https://www.inmuebles24.com/quinta-en-renta-en-zapopan.html
+Inmuebles24,Guadalajara,renta,Quinta,https://www.inmuebles24.com/quinta-en-renta-en-guadalajara.html
+Inmuebles24,San Pedro Tlaquepaque,renta,Quinta,https://www.inmuebles24.com/quinta-en-renta-en-san-pedro-tlaquepaque.html
+Inmuebles24,Tonalá,renta,Quinta,https://www.inmuebles24.com/quinta-en-renta-en-tonala.html
+Inmuebles24,Zapotlanejo,renta,Quinta,https://www.inmuebles24.com/quinta-en-renta-en-zapotlanejo.html
+Inmuebles24,Juanacatlán,renta,Quinta,https://www.inmuebles24.com/quinta-en-renta-en-juanacatlan.html
+Inmuebles24,Ixtlahuacán de los Membrillos,renta,Quinta,https://www.inmuebles24.com/quinta-en-renta-en-ixtlahuacan-de-los-membrillos.html
+Inmuebles24,El Salto,renta,Quinta,https://www.inmuebles24.com/quinta-en-renta-en-el-salto.html
+Inmuebles24,Tlajomulco de Zuñiga,renta,Quinta,https://www.inmuebles24.com/quinta-en-renta-en-tlajomulco-de-zuniga.html
+Inmuebles24,Zapopan,renta,Terreno comercial,https://www.inmuebles24.com/terreno-comercial-en-renta-en-zapopan.html
+Inmuebles24,Guadalajara,renta,Terreno comercial,https://www.inmuebles24.com/terreno-comercial-en-renta-en-guadalajara.html
+Inmuebles24,San Pedro Tlaquepaque,renta,Terreno comercial,https://www.inmuebles24.com/terreno-comercial-en-renta-en-san-pedro-tlaquepaque.html
+Inmuebles24,Tonalá,renta,Terreno comercial,https://www.inmuebles24.com/terreno-comercial-en-renta-en-tonala.html
+Inmuebles24,Zapotlanejo,renta,Terreno comercial,https://www.inmuebles24.com/terreno-comercial-en-renta-en-zapotlanejo.html
+Inmuebles24,Juanacatlán,renta,Terreno comercial,https://www.inmuebles24.com/terreno-comercial-en-renta-en-juanacatlan.html
+Inmuebles24,Ixtlahuacán de los Membrillos,renta,Terreno comercial,https://www.inmuebles24.com/terreno-comercial-en-renta-en-ixtlahuacan-de-los-membrillos.html
+Inmuebles24,El Salto,renta,Terreno comercial,https://www.inmuebles24.com/terreno-comercial-en-renta-en-el-salto.html
+Inmuebles24,Tlajomulco de Zuñiga,renta,Terreno comercial,https://www.inmuebles24.com/terreno-comercial-en-renta-en-tlajomulco-de-zuniga.html
+Inmuebles24,Zapopan,renta,Terreno industrial,https://www.inmuebles24.com/terreno-industrial-en-renta-en-zapopan.html
+Inmuebles24,Guadalajara,renta,Terreno industrial,https://www.inmuebles24.com/terreno-industrial-en-renta-en-guadalajara.html
+Inmuebles24,San Pedro Tlaquepaque,renta,Terreno industrial,https://www.inmuebles24.com/terreno-industrial-en-renta-en-san-pedro-tlaquepaque.html
+Inmuebles24,Tonalá,renta,Terreno industrial,https://www.inmuebles24.com/terreno-industrial-en-renta-en-tonala.html
+Inmuebles24,Zapotlanejo,renta,Terreno industrial,https://www.inmuebles24.com/terreno-industrial-en-renta-en-zapotlanejo.html
+Inmuebles24,Juanacatlán,renta,Terreno industrial,https://www.inmuebles24.com/terreno-industrial-en-renta-en-juanacatlan.html
+Inmuebles24,Ixtlahuacán de los Membrillos,renta,Terreno industrial,https://www.inmuebles24.com/terreno-industrial-en-renta-en-ixtlahuacan-de-los-membrillos.html
+Inmuebles24,El Salto,renta,Terreno industrial,https://www.inmuebles24.com/terreno-industrial-en-renta-en-el-salto.html
+Inmuebles24,Tlajomulco de Zuñiga,renta,Terreno industrial,https://www.inmuebles24.com/terreno-industrial-en-renta-en-tlajomulco-de-zuniga.html
+Inmuebles24,Zapopan,renta,Terrenos,https://www.inmuebles24.com/terrenos-en-renta-en-zapopan.html
+Inmuebles24,Guadalajara,renta,Terrenos,https://www.inmuebles24.com/terrenos-en-renta-en-guadalajara.html
+Inmuebles24,San Pedro Tlaquepaque,renta,Terrenos,https://www.inmuebles24.com/terrenos-en-renta-en-san-pedro-tlaquepaque.html
+Inmuebles24,Tonalá,renta,Terrenos,https://www.inmuebles24.com/terrenos-en-renta-en-tonala.html
+Inmuebles24,Zapotlanejo,renta,Terrenos,https://www.inmuebles24.com/terrenos-en-renta-en-zapotlanejo.html
+Inmuebles24,Juanacatlán,renta,Terrenos,https://www.inmuebles24.com/terrenos-en-renta-en-juanacatlan.html
+Inmuebles24,Ixtlahuacán de los Membrillos,renta,Terrenos,https://www.inmuebles24.com/terrenos-en-renta-en-ixtlahuacan-de-los-membrillos.html
+Inmuebles24,El Salto,renta,Terrenos,https://www.inmuebles24.com/terrenos-en-renta-en-el-salto.html
+Inmuebles24,Tlajomulco de Zuñiga,renta,Terrenos,https://www.inmuebles24.com/terrenos-en-renta-en-tlajomulco-de-zuniga.html
+Inmuebles24,Zapopan,renta,Villa,https://www.inmuebles24.com/villa-en-renta-en-zapopan.html
+Inmuebles24,Guadalajara,renta,Villa,https://www.inmuebles24.com/villa-en-renta-en-guadalajara.html
+Inmuebles24,San Pedro Tlaquepaque,renta,Villa,https://www.inmuebles24.com/villa-en-renta-en-san-pedro-tlaquepaque.html
+Inmuebles24,Tonalá,renta,Villa,https://www.inmuebles24.com/villa-en-renta-en-tonala.html
+Inmuebles24,Zapotlanejo,renta,Villa,https://www.inmuebles24.com/villa-en-renta-en-zapotlanejo.html
+Inmuebles24,Juanacatlán,renta,Villa,https://www.inmuebles24.com/villa-en-renta-en-juanacatlan.html
+Inmuebles24,Ixtlahuacán de los Membrillos,renta,Villa,https://www.inmuebles24.com/villa-en-renta-en-ixtlahuacan-de-los-membrillos.html
+Inmuebles24,El Salto,renta,Villa,https://www.inmuebles24.com/villa-en-renta-en-el-salto.html
+Inmuebles24,Tlajomulco de Zuñiga,renta,Villa,https://www.inmuebles24.com/villa-en-renta-en-tlajomulco-de-zuniga.html

--- a/URLs/lam_urls.csv
+++ b/URLs/lam_urls.csv
@@ -1,164 +1,163 @@
-# Formato: PaginaWeb,Ciudad,Operación,ProductoPaginaWeb,URL
-PaginaWeb,Ciudad,Operación,ProductoPaginaWeb,URL,ago25_2,sep25_1,sep25_2,oct25_1,oct25_2,nov25_1,nov25_2,dic25_1,dic25_2,ene25_1,ene25_2,feb25_1,feb25_2,mar25_1,mar25_2,abr25_1,abr25_2,may25_1,may25_2,jun25_1,jun25_2,jul25_1,jul25_2,ago25_1,ago25_2,sep25_1,sep25_2
-Casas_y_terrenos,Guadalajara,Venta,Casas,https://www.lamudi.com.mx/jalisco/guadalajara/casa/for-sale/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,Guadalajara,Renta,Casas,https://www.lamudi.com.mx/jalisco/guadalajara/casa/for-rent/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,Guadalajara,Venta,Consultorios,https://www.lamudi.com.mx/jalisco/guadalajara/offices/medico-consulting/for-sale/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,Guadalajara,Renta,Consultorios,https://www.lamudi.com.mx/jalisco/guadalajara/offices/medico-consulting/for-rent/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,Guadalajara,Venta,Departamentos,https://www.lamudi.com.mx/jalisco/guadalajara/departamento/for-sale/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,Guadalajara,Renta,Departamentos,https://www.lamudi.com.mx/jalisco/guadalajara/departamento/for-rent/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,Guadalajara,Venta,Edificios,https://www.lamudi.com.mx/jalisco/guadalajara/offices/edificio/for-sale/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,Guadalajara,Renta,Edificios,https://www.lamudi.com.mx/jalisco/guadalajara/offices/edificio/for-rent/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,Guadalajara,Venta,Locales en Centros Comerciales,https://www.lamudi.com.mx/jalisco/guadalajara/comercial/comercial-agricultura/for-sale/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,Guadalajara,Renta,Locales en Centros Comerciales,https://www.lamudi.com.mx/jalisco/guadalajara/comercial/comercial-agricultura/for-rent/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,Guadalajara,Venta,Locales Retail,https://www.lamudi.com.mx/jalisco/guadalajara/comercial/venta-al-por-menor/for-sale/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,Guadalajara,Renta,Locales Retail,https://www.lamudi.com.mx/jalisco/guadalajara/comercial/venta-al-por-menor/for-rent/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,Guadalajara,Venta,Naves/Bodegas,https://www.lamudi.com.mx/jalisco/guadalajara/comercial/industria-almacen/for-sale/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,Guadalajara,Renta,Naves/Bodegas,https://www.lamudi.com.mx/jalisco/guadalajara/comercial/industria-almacen/for-rent/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,Guadalajara,Venta,Oficinas,https://www.lamudi.com.mx/jalisco/guadalajara/offices/for-sale/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,Guadalajara,Renta,Oficinas,https://www.lamudi.com.mx/jalisco/guadalajara/offices/for-rent/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,Guadalajara,Venta,Terrenos,https://www.lamudi.com.mx/jalisco/guadalajara/terreno/for-sale/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,Guadalajara,Renta,Terrenos,https://www.lamudi.com.mx/jalisco/guadalajara/terreno/for-rent/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,El Salto,Venta,Casas,https://www.lamudi.com.mx/jalisco/el-salto/casa/for-sale/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,El Salto,Renta,Casas,https://www.lamudi.com.mx/jalisco/el-salto/casa/for-rent/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,El Salto,Venta,Consultorios,https://www.lamudi.com.mx/jalisco/el-salto/offices/medico-consulting/for-sale/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,El Salto,Renta,Consultorios,https://www.lamudi.com.mx/jalisco/el-salto/offices/medico-consulting/for-rent/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,El Salto,Venta,Departamentos,https://www.lamudi.com.mx/jalisco/el-salto/departamento/for-sale/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,El Salto,Renta,Departamentos,https://www.lamudi.com.mx/jalisco/el-salto/departamento/for-rent/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,El Salto,Venta,Edificios,https://www.lamudi.com.mx/jalisco/el-salto/offices/edificio/for-sale/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,El Salto,Renta,Edificios,https://www.lamudi.com.mx/jalisco/el-salto/offices/edificio/for-rent/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,El Salto,Venta,Locales en Centros Comerciales,https://www.lamudi.com.mx/jalisco/el-salto/comercial/comercial-agricultura/for-sale/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,El Salto,Renta,Locales en Centros Comerciales,https://www.lamudi.com.mx/jalisco/el-salto/comercial/comercial-agricultura/for-rent/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,El Salto,Venta,Locales Retail,https://www.lamudi.com.mx/jalisco/el-salto/comercial/venta-al-por-menor/for-sale/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,El Salto,Renta,Locales Retail,https://www.lamudi.com.mx/jalisco/el-salto/comercial/venta-al-por-menor/for-rent/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,El Salto,Venta,Naves/Bodegas,https://www.lamudi.com.mx/jalisco/el-salto/comercial/industria-almacen/for-sale/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,El Salto,Renta,Naves/Bodegas,https://www.lamudi.com.mx/jalisco/el-salto/comercial/industria-almacen/for-rent/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,El Salto,Venta,Oficinas,https://www.lamudi.com.mx/jalisco/el-salto/offices/for-sale/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,El Salto,Renta,Oficinas,https://www.lamudi.com.mx/jalisco/el-salto/offices/for-rent/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,El Salto,Venta,Terrenos,https://www.lamudi.com.mx/jalisco/el-salto/terreno/for-sale/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,El Salto,Renta,Terrenos,https://www.lamudi.com.mx/jalisco/el-salto/terreno/for-rent/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,IxtlahuacÃ¡n de los Membrillos,Venta,Casas,https://www.lamudi.com.mx/jalisco/ixtlahuacan-de-los-membrillos/casa/for-sale/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,IxtlahuacÃ¡n de los Membrillos,Renta,Casas,https://www.lamudi.com.mx/jalisco/ixtlahuacan-de-los-membrillos/casa/for-rent/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,IxtlahuacÃ¡n de los Membrillos,Venta,Consultorios,https://www.lamudi.com.mx/jalisco/ixtlahuacan-de-los-membrillos/offices/medico-consulting/for-sale/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,IxtlahuacÃ¡n de los Membrillos,Renta,Consultorios,https://www.lamudi.com.mx/jalisco/ixtlahuacan-de-los-membrillos/offices/medico-consulting/for-rent/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,IxtlahuacÃ¡n de los Membrillos,Venta,Departamentos,https://www.lamudi.com.mx/jalisco/ixtlahuacan-de-los-membrillos/departamento/for-sale/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,IxtlahuacÃ¡n de los Membrillos,Renta,Departamentos,https://www.lamudi.com.mx/jalisco/ixtlahuacan-de-los-membrillos/departamento/for-rent/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,IxtlahuacÃ¡n de los Membrillos,Venta,Edificios,https://www.lamudi.com.mx/jalisco/ixtlahuacan-de-los-membrillos/offices/edificio/for-sale/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,IxtlahuacÃ¡n de los Membrillos,Renta,Edificios,https://www.lamudi.com.mx/jalisco/ixtlahuacan-de-los-membrillos/offices/edificio/for-rent/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,IxtlahuacÃ¡n de los Membrillos,Venta,Locales en Centros Comerciales,https://www.lamudi.com.mx/jalisco/ixtlahuacan-de-los-membrillos/comercial/comercial-agricultura/for-sale/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,IxtlahuacÃ¡n de los Membrillos,Renta,Locales en Centros Comerciales,https://www.lamudi.com.mx/jalisco/ixtlahuacan-de-los-membrillos/comercial/comercial-agricultura/for-rent/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,IxtlahuacÃ¡n de los Membrillos,Venta,Locales Retail,https://www.lamudi.com.mx/jalisco/ixtlahuacan-de-los-membrillos/comercial/venta-al-por-menor/for-sale/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,IxtlahuacÃ¡n de los Membrillos,Renta,Locales Retail,https://www.lamudi.com.mx/jalisco/ixtlahuacan-de-los-membrillos/comercial/venta-al-por-menor/for-rent/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,IxtlahuacÃ¡n de los Membrillos,Venta,Naves/Bodegas,https://www.lamudi.com.mx/jalisco/ixtlahuacan-de-los-membrillos/comercial/industria-almacen/for-sale/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,IxtlahuacÃ¡n de los Membrillos,Renta,Naves/Bodegas,https://www.lamudi.com.mx/jalisco/ixtlahuacan-de-los-membrillos/comercial/industria-almacen/for-rent/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,IxtlahuacÃ¡n de los Membrillos,Venta,Oficinas,https://www.lamudi.com.mx/jalisco/ixtlahuacan-de-los-membrillos/offices/for-sale/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,IxtlahuacÃ¡n de los Membrillos,Renta,Oficinas,https://www.lamudi.com.mx/jalisco/ixtlahuacan-de-los-membrillos/offices/for-rent/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,IxtlahuacÃ¡n de los Membrillos,Venta,Terrenos,https://www.lamudi.com.mx/jalisco/ixtlahuacan-de-los-membrillos/terreno/for-sale/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,IxtlahuacÃ¡n de los Membrillos,Renta,Terrenos,https://www.lamudi.com.mx/jalisco/ixtlahuacan-de-los-membrillos/terreno/for-rent/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,JuanacatlÃ¡n,Venta,Casas,https://www.lamudi.com.mx/jalisco/juanacatlan/casa/for-sale/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,JuanacatlÃ¡n,Renta,Casas,https://www.lamudi.com.mx/jalisco/juanacatlan/casa/for-rent/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,JuanacatlÃ¡n,Venta,Consultorios,https://www.lamudi.com.mx/jalisco/juanacatlan/offices/medico-consulting/for-sale/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,JuanacatlÃ¡n,Renta,Consultorios,https://www.lamudi.com.mx/jalisco/juanacatlan/offices/medico-consulting/for-rent/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,JuanacatlÃ¡n,Venta,Departamentos,https://www.lamudi.com.mx/jalisco/juanacatlan/departamento/for-sale/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,JuanacatlÃ¡n,Renta,Departamentos,https://www.lamudi.com.mx/jalisco/juanacatlan/departamento/for-rent/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,JuanacatlÃ¡n,Venta,Edificios,https://www.lamudi.com.mx/jalisco/juanacatlan/offices/edificio/for-sale/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,JuanacatlÃ¡n,Renta,Edificios,https://www.lamudi.com.mx/jalisco/juanacatlan/offices/edificio/for-rent/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,JuanacatlÃ¡n,Venta,Locales en Centros Comerciales,https://www.lamudi.com.mx/jalisco/juanacatlan/comercial/comercial-agricultura/for-sale/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,JuanacatlÃ¡n,Renta,Locales en Centros Comerciales,https://www.lamudi.com.mx/jalisco/juanacatlan/comercial/comercial-agricultura/for-rent/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,JuanacatlÃ¡n,Venta,Locales Retail,https://www.lamudi.com.mx/jalisco/juanacatlan/comercial/venta-al-por-menor/for-sale/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,JuanacatlÃ¡n,Renta,Locales Retail,https://www.lamudi.com.mx/jalisco/juanacatlan/comercial/venta-al-por-menor/for-rent/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,JuanacatlÃ¡n,Venta,Naves/Bodegas,https://www.lamudi.com.mx/jalisco/juanacatlan/comercial/industria-almacen/for-sale/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,JuanacatlÃ¡n,Renta,Naves/Bodegas,https://www.lamudi.com.mx/jalisco/juanacatlan/comercial/industria-almacen/for-rent/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,JuanacatlÃ¡n,Venta,Oficinas,https://www.lamudi.com.mx/jalisco/juanacatlan/offices/for-sale/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,JuanacatlÃ¡n,Renta,Oficinas,https://www.lamudi.com.mx/jalisco/juanacatlan/offices/for-rent/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,JuanacatlÃ¡n,Venta,Terrenos,https://www.lamudi.com.mx/jalisco/juanacatlan/terreno/for-sale/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,JuanacatlÃ¡n,Renta,Terrenos,https://www.lamudi.com.mx/jalisco/juanacatlan/terreno/for-rent/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,San Pedro Tlaquepaque,Venta,Casas,https://www.lamudi.com.mx/jalisco/tlaquepaque/casa/for-sale/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,San Pedro Tlaquepaque,Renta,Casas,https://www.lamudi.com.mx/jalisco/tlaquepaque/casa/for-rent/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,San Pedro Tlaquepaque,Venta,Consultorios,https://www.lamudi.com.mx/jalisco/tlaquepaque/offices/medico-consulting/for-sale/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,San Pedro Tlaquepaque,Renta,Consultorios,https://www.lamudi.com.mx/jalisco/tlaquepaque/offices/medico-consulting/for-rent/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,San Pedro Tlaquepaque,Venta,Departamentos,https://www.lamudi.com.mx/jalisco/tlaquepaque/departamento/for-sale/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,San Pedro Tlaquepaque,Renta,Departamentos,https://www.lamudi.com.mx/jalisco/tlaquepaque/departamento/for-rent/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,San Pedro Tlaquepaque,Venta,Edificios,https://www.lamudi.com.mx/jalisco/tlaquepaque/offices/edificio/for-sale/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,San Pedro Tlaquepaque,Renta,Edificios,https://www.lamudi.com.mx/jalisco/tlaquepaque/offices/edificio/for-rent/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,San Pedro Tlaquepaque,Venta,Locales en Centros Comerciales,https://www.lamudi.com.mx/jalisco/tlaquepaque/comercial/comercial-agricultura/for-sale/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,San Pedro Tlaquepaque,Renta,Locales en Centros Comerciales,https://www.lamudi.com.mx/jalisco/tlaquepaque/comercial/comercial-agricultura/for-rent/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,San Pedro Tlaquepaque,Venta,Locales Retail,https://www.lamudi.com.mx/jalisco/tlaquepaque/comercial/venta-al-por-menor/for-sale/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,San Pedro Tlaquepaque,Renta,Locales Retail,https://www.lamudi.com.mx/jalisco/tlaquepaque/comercial/venta-al-por-menor/for-rent/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,San Pedro Tlaquepaque,Venta,Naves/Bodegas,https://www.lamudi.com.mx/jalisco/tlaquepaque/comercial/industria-almacen/for-sale/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,San Pedro Tlaquepaque,Renta,Naves/Bodegas,https://www.lamudi.com.mx/jalisco/tlaquepaque/comercial/industria-almacen/for-rent/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,San Pedro Tlaquepaque,Venta,Oficinas,https://www.lamudi.com.mx/jalisco/tlaquepaque/offices/for-sale/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,San Pedro Tlaquepaque,Renta,Oficinas,https://www.lamudi.com.mx/jalisco/tlaquepaque/offices/for-rent/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,San Pedro Tlaquepaque,Venta,Terrenos,https://www.lamudi.com.mx/jalisco/tlaquepaque/terreno/for-sale/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,San Pedro Tlaquepaque,Renta,Terrenos,https://www.lamudi.com.mx/jalisco/tlaquepaque/terreno/for-rent/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,Tlajomulco de ZÃºÃ±iga,Venta,Casas,https://www.lamudi.com.mx/jalisco/tlajomulco-de-zuniga/casa/for-sale/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,Tlajomulco de ZÃºÃ±iga,Renta,Casas,https://www.lamudi.com.mx/jalisco/tlajomulco-de-zuniga/casa/for-rent/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,Tlajomulco de ZÃºÃ±iga,Venta,Consultorios,https://www.lamudi.com.mx/jalisco/tlajomulco-de-zuniga/offices/medico-consulting/for-sale/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,Tlajomulco de ZÃºÃ±iga,Renta,Consultorios,https://www.lamudi.com.mx/jalisco/tlajomulco-de-zuniga/offices/medico-consulting/for-rent/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,Tlajomulco de ZÃºÃ±iga,Venta,Departamentos,https://www.lamudi.com.mx/jalisco/tlajomulco-de-zuniga/departamento/for-sale/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,Tlajomulco de ZÃºÃ±iga,Renta,Departamentos,https://www.lamudi.com.mx/jalisco/tlajomulco-de-zuniga/departamento/for-rent/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,Tlajomulco de ZÃºÃ±iga,Venta,Edificios,https://www.lamudi.com.mx/jalisco/tlajomulco-de-zuniga/offices/edificio/for-sale/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,Tlajomulco de ZÃºÃ±iga,Renta,Edificios,https://www.lamudi.com.mx/jalisco/tlajomulco-de-zuniga/offices/edificio/for-rent/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,Tlajomulco de ZÃºÃ±iga,Venta,Locales en Centros Comerciales,https://www.lamudi.com.mx/jalisco/tlajomulco-de-zuniga/comercial/comercial-agricultura/for-sale/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,Tlajomulco de ZÃºÃ±iga,Renta,Locales en Centros Comerciales,https://www.lamudi.com.mx/jalisco/tlajomulco-de-zuniga/comercial/comercial-agricultura/for-rent/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,Tlajomulco de ZÃºÃ±iga,Venta,Locales Retail,https://www.lamudi.com.mx/jalisco/tlajomulco-de-zuniga/comercial/venta-al-por-menor/for-sale/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,Tlajomulco de ZÃºÃ±iga,Renta,Locales Retail,https://www.lamudi.com.mx/jalisco/tlajomulco-de-zuniga/comercial/venta-al-por-menor/for-rent/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,Tlajomulco de ZÃºÃ±iga,Venta,Naves/Bodegas,https://www.lamudi.com.mx/jalisco/tlajomulco-de-zuniga/comercial/industria-almacen/for-sale/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,Tlajomulco de ZÃºÃ±iga,Renta,Naves/Bodegas,https://www.lamudi.com.mx/jalisco/tlajomulco-de-zuniga/comercial/industria-almacen/for-rent/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,Tlajomulco de ZÃºÃ±iga,Venta,Oficinas,https://www.lamudi.com.mx/jalisco/tlajomulco-de-zuniga/offices/for-sale/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,Tlajomulco de ZÃºÃ±iga,Renta,Oficinas,https://www.lamudi.com.mx/jalisco/tlajomulco-de-zuniga/offices/for-rent/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,Tlajomulco de ZÃºÃ±iga,Venta,Terrenos,https://www.lamudi.com.mx/jalisco/tlajomulco-de-zuniga/terreno/for-sale/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,Tlajomulco de ZÃºÃ±iga,Renta,Terrenos,https://www.lamudi.com.mx/jalisco/tlajomulco-de-zuniga/terreno/for-rent/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,TonalÃ¡,Venta,Casas,https://www.lamudi.com.mx/jalisco/tonala-1/casa/for-sale/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,TonalÃ¡,Renta,Casas,https://www.lamudi.com.mx/jalisco/tonala-1/casa/for-rent/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,TonalÃ¡,Venta,Consultorios,https://www.lamudi.com.mx/jalisco/tonala-1/offices/medico-consulting/for-sale/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,TonalÃ¡,Renta,Consultorios,https://www.lamudi.com.mx/jalisco/tonala-1/offices/medico-consulting/for-rent/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,TonalÃ¡,Venta,Departamentos,https://www.lamudi.com.mx/jalisco/tonala-1/departamento/for-sale/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,TonalÃ¡,Renta,Departamentos,https://www.lamudi.com.mx/jalisco/tonala-1/departamento/for-rent/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,TonalÃ¡,Venta,Edificios,https://www.lamudi.com.mx/jalisco/tonala-1/offices/edificio/for-sale/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,TonalÃ¡,Renta,Edificios,https://www.lamudi.com.mx/jalisco/tonala-1/offices/edificio/for-rent/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,TonalÃ¡,Venta,Locales en Centros Comerciales,https://www.lamudi.com.mx/jalisco/tonala-1/comercial/comercial-agricultura/for-sale/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,TonalÃ¡,Renta,Locales en Centros Comerciales,https://www.lamudi.com.mx/jalisco/tonala-1/comercial/comercial-agricultura/for-rent/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,TonalÃ¡,Venta,Locales Retail,https://www.lamudi.com.mx/jalisco/tonala-1/comercial/venta-al-por-menor/for-sale/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,TonalÃ¡,Renta,Locales Retail,https://www.lamudi.com.mx/jalisco/tonala-1/comercial/venta-al-por-menor/for-rent/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,TonalÃ¡,Venta,Naves/Bodegas,https://www.lamudi.com.mx/jalisco/tonala-1/comercial/industria-almacen/for-sale/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,TonalÃ¡,Renta,Naves/Bodegas,https://www.lamudi.com.mx/jalisco/tonala-1/comercial/industria-almacen/for-rent/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,TonalÃ¡,Venta,Oficinas,https://www.lamudi.com.mx/jalisco/tonala-1/offices/for-sale/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,TonalÃ¡,Renta,Oficinas,https://www.lamudi.com.mx/jalisco/tonala-1/offices/for-rent/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,TonalÃ¡,Venta,Terrenos,https://www.lamudi.com.mx/jalisco/tonala-1/terreno/for-sale/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,TonalÃ¡,Renta,Terrenos,https://www.lamudi.com.mx/jalisco/tonala-1/terreno/for-rent/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,Zapopan,Venta,Casas,https://www.lamudi.com.mx/jalisco/zapopan/casa/for-sale/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,Zapopan,Renta,Casas,https://www.lamudi.com.mx/jalisco/zapopan/casa/for-rent/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,Zapopan,Venta,Consultorios,https://www.lamudi.com.mx/jalisco/zapopan/offices/medico-consulting/for-sale/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,Zapopan,Renta,Consultorios,https://www.lamudi.com.mx/jalisco/zapopan/offices/medico-consulting/for-rent/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,Zapopan,Venta,Departamentos,https://www.lamudi.com.mx/jalisco/zapopan/departamento/for-sale/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,Zapopan,Renta,Departamentos,https://www.lamudi.com.mx/jalisco/zapopan/departamento/for-rent/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,Zapopan,Venta,Edificios,https://www.lamudi.com.mx/jalisco/zapopan/offices/edificio/for-sale/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,Zapopan,Renta,Edificios,https://www.lamudi.com.mx/jalisco/zapopan/offices/edificio/for-rent/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,Zapopan,Venta,Locales en Centros Comerciales,https://www.lamudi.com.mx/jalisco/zapopan/comercial/comercial-agricultura/for-sale/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,Zapopan,Renta,Locales en Centros Comerciales,https://www.lamudi.com.mx/jalisco/zapopan/comercial/comercial-agricultura/for-rent/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,Zapopan,Venta,Locales Retail,https://www.lamudi.com.mx/jalisco/zapopan/comercial/venta-al-por-menor/for-sale/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,Zapopan,Renta,Locales Retail,https://www.lamudi.com.mx/jalisco/zapopan/comercial/venta-al-por-menor/for-rent/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,Zapopan,Venta,Naves/Bodegas,https://www.lamudi.com.mx/jalisco/zapopan/comercial/industria-almacen/for-sale/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,Zapopan,Renta,Naves/Bodegas,https://www.lamudi.com.mx/jalisco/zapopan/comercial/industria-almacen/for-rent/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,Zapopan,Venta,Oficinas,https://www.lamudi.com.mx/jalisco/zapopan/offices/for-sale/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,Zapopan,Renta,Oficinas,https://www.lamudi.com.mx/jalisco/zapopan/offices/for-rent/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,Zapopan,Venta,Terrenos,https://www.lamudi.com.mx/jalisco/zapopan/terreno/for-sale/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,Zapopan,Renta,Terrenos,https://www.lamudi.com.mx/jalisco/zapopan/terreno/for-rent/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,Zapotlanejo,Venta,Casas,https://www.lamudi.com.mx/jalisco/zapotlanejo/casa/for-sale/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,Zapotlanejo,Renta,Casas,https://www.lamudi.com.mx/jalisco/zapotlanejo/casa/for-rent/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,Zapotlanejo,Venta,Consultorios,https://www.lamudi.com.mx/jalisco/zapotlanejo/offices/medico-consulting/for-sale/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,Zapotlanejo,Renta,Consultorios,https://www.lamudi.com.mx/jalisco/zapotlanejo/offices/medico-consulting/for-rent/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,Zapotlanejo,Venta,Departamentos,https://www.lamudi.com.mx/jalisco/zapotlanejo/departamento/for-sale/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,Zapotlanejo,Renta,Departamentos,https://www.lamudi.com.mx/jalisco/zapotlanejo/departamento/for-rent/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,Zapotlanejo,Venta,Edificios,https://www.lamudi.com.mx/jalisco/zapotlanejo/offices/edificio/for-sale/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,Zapotlanejo,Renta,Edificios,https://www.lamudi.com.mx/jalisco/zapotlanejo/offices/edificio/for-rent/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,Zapotlanejo,Venta,Locales en Centros Comerciales,https://www.lamudi.com.mx/jalisco/zapotlanejo/comercial/comercial-agricultura/for-sale/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,Zapotlanejo,Renta,Locales en Centros Comerciales,https://www.lamudi.com.mx/jalisco/zapotlanejo/comercial/comercial-agricultura/for-rent/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,Zapotlanejo,Venta,Locales Retail,https://www.lamudi.com.mx/jalisco/zapotlanejo/comercial/venta-al-por-menor/for-sale/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,Zapotlanejo,Renta,Locales Retail,https://www.lamudi.com.mx/jalisco/zapotlanejo/comercial/venta-al-por-menor/for-rent/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,Zapotlanejo,Venta,Naves/Bodegas,https://www.lamudi.com.mx/jalisco/zapotlanejo/comercial/industria-almacen/for-sale/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,Zapotlanejo,Renta,Naves/Bodegas,https://www.lamudi.com.mx/jalisco/zapotlanejo/comercial/industria-almacen/for-rent/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,Zapotlanejo,Venta,Oficinas,https://www.lamudi.com.mx/jalisco/zapotlanejo/offices/for-sale/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,Zapotlanejo,Renta,Oficinas,https://www.lamudi.com.mx/jalisco/zapotlanejo/offices/for-rent/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,Zapotlanejo,Venta,Terrenos,https://www.lamudi.com.mx/jalisco/zapotlanejo/terreno/for-sale/,,,,,,,,,,,,,,,,,,,,,,,,,,,
-Casas_y_terrenos,Zapotlanejo,Renta,Terrenos,https://www.lamudi.com.mx/jalisco/zapotlanejo/terreno/for-rent/,,,,,,,,,,,,,,,,,,,,,,,,,,,
+PaginaWeb,Ciudad,Operación,ProductoPaginaWeb,URL
+Casas_y_terrenos,Guadalajara,Venta,Casas,https://www.lamudi.com.mx/jalisco/guadalajara/casa/for-sale/
+Casas_y_terrenos,Guadalajara,Renta,Casas,https://www.lamudi.com.mx/jalisco/guadalajara/casa/for-rent/
+Casas_y_terrenos,Guadalajara,Venta,Consultorios,https://www.lamudi.com.mx/jalisco/guadalajara/offices/medico-consulting/for-sale/
+Casas_y_terrenos,Guadalajara,Renta,Consultorios,https://www.lamudi.com.mx/jalisco/guadalajara/offices/medico-consulting/for-rent/
+Casas_y_terrenos,Guadalajara,Venta,Departamentos,https://www.lamudi.com.mx/jalisco/guadalajara/departamento/for-sale/
+Casas_y_terrenos,Guadalajara,Renta,Departamentos,https://www.lamudi.com.mx/jalisco/guadalajara/departamento/for-rent/
+Casas_y_terrenos,Guadalajara,Venta,Edificios,https://www.lamudi.com.mx/jalisco/guadalajara/offices/edificio/for-sale/
+Casas_y_terrenos,Guadalajara,Renta,Edificios,https://www.lamudi.com.mx/jalisco/guadalajara/offices/edificio/for-rent/
+Casas_y_terrenos,Guadalajara,Venta,Locales en Centros Comerciales,https://www.lamudi.com.mx/jalisco/guadalajara/comercial/comercial-agricultura/for-sale/
+Casas_y_terrenos,Guadalajara,Renta,Locales en Centros Comerciales,https://www.lamudi.com.mx/jalisco/guadalajara/comercial/comercial-agricultura/for-rent/
+Casas_y_terrenos,Guadalajara,Venta,Locales Retail,https://www.lamudi.com.mx/jalisco/guadalajara/comercial/venta-al-por-menor/for-sale/
+Casas_y_terrenos,Guadalajara,Renta,Locales Retail,https://www.lamudi.com.mx/jalisco/guadalajara/comercial/venta-al-por-menor/for-rent/
+Casas_y_terrenos,Guadalajara,Venta,Naves/Bodegas,https://www.lamudi.com.mx/jalisco/guadalajara/comercial/industria-almacen/for-sale/
+Casas_y_terrenos,Guadalajara,Renta,Naves/Bodegas,https://www.lamudi.com.mx/jalisco/guadalajara/comercial/industria-almacen/for-rent/
+Casas_y_terrenos,Guadalajara,Venta,Oficinas,https://www.lamudi.com.mx/jalisco/guadalajara/offices/for-sale/
+Casas_y_terrenos,Guadalajara,Renta,Oficinas,https://www.lamudi.com.mx/jalisco/guadalajara/offices/for-rent/
+Casas_y_terrenos,Guadalajara,Venta,Terrenos,https://www.lamudi.com.mx/jalisco/guadalajara/terreno/for-sale/
+Casas_y_terrenos,Guadalajara,Renta,Terrenos,https://www.lamudi.com.mx/jalisco/guadalajara/terreno/for-rent/
+Casas_y_terrenos,El Salto,Venta,Casas,https://www.lamudi.com.mx/jalisco/el-salto/casa/for-sale/
+Casas_y_terrenos,El Salto,Renta,Casas,https://www.lamudi.com.mx/jalisco/el-salto/casa/for-rent/
+Casas_y_terrenos,El Salto,Venta,Consultorios,https://www.lamudi.com.mx/jalisco/el-salto/offices/medico-consulting/for-sale/
+Casas_y_terrenos,El Salto,Renta,Consultorios,https://www.lamudi.com.mx/jalisco/el-salto/offices/medico-consulting/for-rent/
+Casas_y_terrenos,El Salto,Venta,Departamentos,https://www.lamudi.com.mx/jalisco/el-salto/departamento/for-sale/
+Casas_y_terrenos,El Salto,Renta,Departamentos,https://www.lamudi.com.mx/jalisco/el-salto/departamento/for-rent/
+Casas_y_terrenos,El Salto,Venta,Edificios,https://www.lamudi.com.mx/jalisco/el-salto/offices/edificio/for-sale/
+Casas_y_terrenos,El Salto,Renta,Edificios,https://www.lamudi.com.mx/jalisco/el-salto/offices/edificio/for-rent/
+Casas_y_terrenos,El Salto,Venta,Locales en Centros Comerciales,https://www.lamudi.com.mx/jalisco/el-salto/comercial/comercial-agricultura/for-sale/
+Casas_y_terrenos,El Salto,Renta,Locales en Centros Comerciales,https://www.lamudi.com.mx/jalisco/el-salto/comercial/comercial-agricultura/for-rent/
+Casas_y_terrenos,El Salto,Venta,Locales Retail,https://www.lamudi.com.mx/jalisco/el-salto/comercial/venta-al-por-menor/for-sale/
+Casas_y_terrenos,El Salto,Renta,Locales Retail,https://www.lamudi.com.mx/jalisco/el-salto/comercial/venta-al-por-menor/for-rent/
+Casas_y_terrenos,El Salto,Venta,Naves/Bodegas,https://www.lamudi.com.mx/jalisco/el-salto/comercial/industria-almacen/for-sale/
+Casas_y_terrenos,El Salto,Renta,Naves/Bodegas,https://www.lamudi.com.mx/jalisco/el-salto/comercial/industria-almacen/for-rent/
+Casas_y_terrenos,El Salto,Venta,Oficinas,https://www.lamudi.com.mx/jalisco/el-salto/offices/for-sale/
+Casas_y_terrenos,El Salto,Renta,Oficinas,https://www.lamudi.com.mx/jalisco/el-salto/offices/for-rent/
+Casas_y_terrenos,El Salto,Venta,Terrenos,https://www.lamudi.com.mx/jalisco/el-salto/terreno/for-sale/
+Casas_y_terrenos,El Salto,Renta,Terrenos,https://www.lamudi.com.mx/jalisco/el-salto/terreno/for-rent/
+Casas_y_terrenos,Ixtlahuacán de los Membrillos,Venta,Casas,https://www.lamudi.com.mx/jalisco/ixtlahuacan-de-los-membrillos/casa/for-sale/
+Casas_y_terrenos,Ixtlahuacán de los Membrillos,Renta,Casas,https://www.lamudi.com.mx/jalisco/ixtlahuacan-de-los-membrillos/casa/for-rent/
+Casas_y_terrenos,Ixtlahuacán de los Membrillos,Venta,Consultorios,https://www.lamudi.com.mx/jalisco/ixtlahuacan-de-los-membrillos/offices/medico-consulting/for-sale/
+Casas_y_terrenos,Ixtlahuacán de los Membrillos,Renta,Consultorios,https://www.lamudi.com.mx/jalisco/ixtlahuacan-de-los-membrillos/offices/medico-consulting/for-rent/
+Casas_y_terrenos,Ixtlahuacán de los Membrillos,Venta,Departamentos,https://www.lamudi.com.mx/jalisco/ixtlahuacan-de-los-membrillos/departamento/for-sale/
+Casas_y_terrenos,Ixtlahuacán de los Membrillos,Renta,Departamentos,https://www.lamudi.com.mx/jalisco/ixtlahuacan-de-los-membrillos/departamento/for-rent/
+Casas_y_terrenos,Ixtlahuacán de los Membrillos,Venta,Edificios,https://www.lamudi.com.mx/jalisco/ixtlahuacan-de-los-membrillos/offices/edificio/for-sale/
+Casas_y_terrenos,Ixtlahuacán de los Membrillos,Renta,Edificios,https://www.lamudi.com.mx/jalisco/ixtlahuacan-de-los-membrillos/offices/edificio/for-rent/
+Casas_y_terrenos,Ixtlahuacán de los Membrillos,Venta,Locales en Centros Comerciales,https://www.lamudi.com.mx/jalisco/ixtlahuacan-de-los-membrillos/comercial/comercial-agricultura/for-sale/
+Casas_y_terrenos,Ixtlahuacán de los Membrillos,Renta,Locales en Centros Comerciales,https://www.lamudi.com.mx/jalisco/ixtlahuacan-de-los-membrillos/comercial/comercial-agricultura/for-rent/
+Casas_y_terrenos,Ixtlahuacán de los Membrillos,Venta,Locales Retail,https://www.lamudi.com.mx/jalisco/ixtlahuacan-de-los-membrillos/comercial/venta-al-por-menor/for-sale/
+Casas_y_terrenos,Ixtlahuacán de los Membrillos,Renta,Locales Retail,https://www.lamudi.com.mx/jalisco/ixtlahuacan-de-los-membrillos/comercial/venta-al-por-menor/for-rent/
+Casas_y_terrenos,Ixtlahuacán de los Membrillos,Venta,Naves/Bodegas,https://www.lamudi.com.mx/jalisco/ixtlahuacan-de-los-membrillos/comercial/industria-almacen/for-sale/
+Casas_y_terrenos,Ixtlahuacán de los Membrillos,Renta,Naves/Bodegas,https://www.lamudi.com.mx/jalisco/ixtlahuacan-de-los-membrillos/comercial/industria-almacen/for-rent/
+Casas_y_terrenos,Ixtlahuacán de los Membrillos,Venta,Oficinas,https://www.lamudi.com.mx/jalisco/ixtlahuacan-de-los-membrillos/offices/for-sale/
+Casas_y_terrenos,Ixtlahuacán de los Membrillos,Renta,Oficinas,https://www.lamudi.com.mx/jalisco/ixtlahuacan-de-los-membrillos/offices/for-rent/
+Casas_y_terrenos,Ixtlahuacán de los Membrillos,Venta,Terrenos,https://www.lamudi.com.mx/jalisco/ixtlahuacan-de-los-membrillos/terreno/for-sale/
+Casas_y_terrenos,Ixtlahuacán de los Membrillos,Renta,Terrenos,https://www.lamudi.com.mx/jalisco/ixtlahuacan-de-los-membrillos/terreno/for-rent/
+Casas_y_terrenos,Juanacatlán,Venta,Casas,https://www.lamudi.com.mx/jalisco/juanacatlan/casa/for-sale/
+Casas_y_terrenos,Juanacatlán,Renta,Casas,https://www.lamudi.com.mx/jalisco/juanacatlan/casa/for-rent/
+Casas_y_terrenos,Juanacatlán,Venta,Consultorios,https://www.lamudi.com.mx/jalisco/juanacatlan/offices/medico-consulting/for-sale/
+Casas_y_terrenos,Juanacatlán,Renta,Consultorios,https://www.lamudi.com.mx/jalisco/juanacatlan/offices/medico-consulting/for-rent/
+Casas_y_terrenos,Juanacatlán,Venta,Departamentos,https://www.lamudi.com.mx/jalisco/juanacatlan/departamento/for-sale/
+Casas_y_terrenos,Juanacatlán,Renta,Departamentos,https://www.lamudi.com.mx/jalisco/juanacatlan/departamento/for-rent/
+Casas_y_terrenos,Juanacatlán,Venta,Edificios,https://www.lamudi.com.mx/jalisco/juanacatlan/offices/edificio/for-sale/
+Casas_y_terrenos,Juanacatlán,Renta,Edificios,https://www.lamudi.com.mx/jalisco/juanacatlan/offices/edificio/for-rent/
+Casas_y_terrenos,Juanacatlán,Venta,Locales en Centros Comerciales,https://www.lamudi.com.mx/jalisco/juanacatlan/comercial/comercial-agricultura/for-sale/
+Casas_y_terrenos,Juanacatlán,Renta,Locales en Centros Comerciales,https://www.lamudi.com.mx/jalisco/juanacatlan/comercial/comercial-agricultura/for-rent/
+Casas_y_terrenos,Juanacatlán,Venta,Locales Retail,https://www.lamudi.com.mx/jalisco/juanacatlan/comercial/venta-al-por-menor/for-sale/
+Casas_y_terrenos,Juanacatlán,Renta,Locales Retail,https://www.lamudi.com.mx/jalisco/juanacatlan/comercial/venta-al-por-menor/for-rent/
+Casas_y_terrenos,Juanacatlán,Venta,Naves/Bodegas,https://www.lamudi.com.mx/jalisco/juanacatlan/comercial/industria-almacen/for-sale/
+Casas_y_terrenos,Juanacatlán,Renta,Naves/Bodegas,https://www.lamudi.com.mx/jalisco/juanacatlan/comercial/industria-almacen/for-rent/
+Casas_y_terrenos,Juanacatlán,Venta,Oficinas,https://www.lamudi.com.mx/jalisco/juanacatlan/offices/for-sale/
+Casas_y_terrenos,Juanacatlán,Renta,Oficinas,https://www.lamudi.com.mx/jalisco/juanacatlan/offices/for-rent/
+Casas_y_terrenos,Juanacatlán,Venta,Terrenos,https://www.lamudi.com.mx/jalisco/juanacatlan/terreno/for-sale/
+Casas_y_terrenos,Juanacatlán,Renta,Terrenos,https://www.lamudi.com.mx/jalisco/juanacatlan/terreno/for-rent/
+Casas_y_terrenos,San Pedro Tlaquepaque,Venta,Casas,https://www.lamudi.com.mx/jalisco/tlaquepaque/casa/for-sale/
+Casas_y_terrenos,San Pedro Tlaquepaque,Renta,Casas,https://www.lamudi.com.mx/jalisco/tlaquepaque/casa/for-rent/
+Casas_y_terrenos,San Pedro Tlaquepaque,Venta,Consultorios,https://www.lamudi.com.mx/jalisco/tlaquepaque/offices/medico-consulting/for-sale/
+Casas_y_terrenos,San Pedro Tlaquepaque,Renta,Consultorios,https://www.lamudi.com.mx/jalisco/tlaquepaque/offices/medico-consulting/for-rent/
+Casas_y_terrenos,San Pedro Tlaquepaque,Venta,Departamentos,https://www.lamudi.com.mx/jalisco/tlaquepaque/departamento/for-sale/
+Casas_y_terrenos,San Pedro Tlaquepaque,Renta,Departamentos,https://www.lamudi.com.mx/jalisco/tlaquepaque/departamento/for-rent/
+Casas_y_terrenos,San Pedro Tlaquepaque,Venta,Edificios,https://www.lamudi.com.mx/jalisco/tlaquepaque/offices/edificio/for-sale/
+Casas_y_terrenos,San Pedro Tlaquepaque,Renta,Edificios,https://www.lamudi.com.mx/jalisco/tlaquepaque/offices/edificio/for-rent/
+Casas_y_terrenos,San Pedro Tlaquepaque,Venta,Locales en Centros Comerciales,https://www.lamudi.com.mx/jalisco/tlaquepaque/comercial/comercial-agricultura/for-sale/
+Casas_y_terrenos,San Pedro Tlaquepaque,Renta,Locales en Centros Comerciales,https://www.lamudi.com.mx/jalisco/tlaquepaque/comercial/comercial-agricultura/for-rent/
+Casas_y_terrenos,San Pedro Tlaquepaque,Venta,Locales Retail,https://www.lamudi.com.mx/jalisco/tlaquepaque/comercial/venta-al-por-menor/for-sale/
+Casas_y_terrenos,San Pedro Tlaquepaque,Renta,Locales Retail,https://www.lamudi.com.mx/jalisco/tlaquepaque/comercial/venta-al-por-menor/for-rent/
+Casas_y_terrenos,San Pedro Tlaquepaque,Venta,Naves/Bodegas,https://www.lamudi.com.mx/jalisco/tlaquepaque/comercial/industria-almacen/for-sale/
+Casas_y_terrenos,San Pedro Tlaquepaque,Renta,Naves/Bodegas,https://www.lamudi.com.mx/jalisco/tlaquepaque/comercial/industria-almacen/for-rent/
+Casas_y_terrenos,San Pedro Tlaquepaque,Venta,Oficinas,https://www.lamudi.com.mx/jalisco/tlaquepaque/offices/for-sale/
+Casas_y_terrenos,San Pedro Tlaquepaque,Renta,Oficinas,https://www.lamudi.com.mx/jalisco/tlaquepaque/offices/for-rent/
+Casas_y_terrenos,San Pedro Tlaquepaque,Venta,Terrenos,https://www.lamudi.com.mx/jalisco/tlaquepaque/terreno/for-sale/
+Casas_y_terrenos,San Pedro Tlaquepaque,Renta,Terrenos,https://www.lamudi.com.mx/jalisco/tlaquepaque/terreno/for-rent/
+Casas_y_terrenos,Tlajomulco de Zúñiga,Venta,Casas,https://www.lamudi.com.mx/jalisco/tlajomulco-de-zuniga/casa/for-sale/
+Casas_y_terrenos,Tlajomulco de Zúñiga,Renta,Casas,https://www.lamudi.com.mx/jalisco/tlajomulco-de-zuniga/casa/for-rent/
+Casas_y_terrenos,Tlajomulco de Zúñiga,Venta,Consultorios,https://www.lamudi.com.mx/jalisco/tlajomulco-de-zuniga/offices/medico-consulting/for-sale/
+Casas_y_terrenos,Tlajomulco de Zúñiga,Renta,Consultorios,https://www.lamudi.com.mx/jalisco/tlajomulco-de-zuniga/offices/medico-consulting/for-rent/
+Casas_y_terrenos,Tlajomulco de Zúñiga,Venta,Departamentos,https://www.lamudi.com.mx/jalisco/tlajomulco-de-zuniga/departamento/for-sale/
+Casas_y_terrenos,Tlajomulco de Zúñiga,Renta,Departamentos,https://www.lamudi.com.mx/jalisco/tlajomulco-de-zuniga/departamento/for-rent/
+Casas_y_terrenos,Tlajomulco de Zúñiga,Venta,Edificios,https://www.lamudi.com.mx/jalisco/tlajomulco-de-zuniga/offices/edificio/for-sale/
+Casas_y_terrenos,Tlajomulco de Zúñiga,Renta,Edificios,https://www.lamudi.com.mx/jalisco/tlajomulco-de-zuniga/offices/edificio/for-rent/
+Casas_y_terrenos,Tlajomulco de Zúñiga,Venta,Locales en Centros Comerciales,https://www.lamudi.com.mx/jalisco/tlajomulco-de-zuniga/comercial/comercial-agricultura/for-sale/
+Casas_y_terrenos,Tlajomulco de Zúñiga,Renta,Locales en Centros Comerciales,https://www.lamudi.com.mx/jalisco/tlajomulco-de-zuniga/comercial/comercial-agricultura/for-rent/
+Casas_y_terrenos,Tlajomulco de Zúñiga,Venta,Locales Retail,https://www.lamudi.com.mx/jalisco/tlajomulco-de-zuniga/comercial/venta-al-por-menor/for-sale/
+Casas_y_terrenos,Tlajomulco de Zúñiga,Renta,Locales Retail,https://www.lamudi.com.mx/jalisco/tlajomulco-de-zuniga/comercial/venta-al-por-menor/for-rent/
+Casas_y_terrenos,Tlajomulco de Zúñiga,Venta,Naves/Bodegas,https://www.lamudi.com.mx/jalisco/tlajomulco-de-zuniga/comercial/industria-almacen/for-sale/
+Casas_y_terrenos,Tlajomulco de Zúñiga,Renta,Naves/Bodegas,https://www.lamudi.com.mx/jalisco/tlajomulco-de-zuniga/comercial/industria-almacen/for-rent/
+Casas_y_terrenos,Tlajomulco de Zúñiga,Venta,Oficinas,https://www.lamudi.com.mx/jalisco/tlajomulco-de-zuniga/offices/for-sale/
+Casas_y_terrenos,Tlajomulco de Zúñiga,Renta,Oficinas,https://www.lamudi.com.mx/jalisco/tlajomulco-de-zuniga/offices/for-rent/
+Casas_y_terrenos,Tlajomulco de Zúñiga,Venta,Terrenos,https://www.lamudi.com.mx/jalisco/tlajomulco-de-zuniga/terreno/for-sale/
+Casas_y_terrenos,Tlajomulco de Zúñiga,Renta,Terrenos,https://www.lamudi.com.mx/jalisco/tlajomulco-de-zuniga/terreno/for-rent/
+Casas_y_terrenos,Tonalá,Venta,Casas,https://www.lamudi.com.mx/jalisco/tonala-1/casa/for-sale/
+Casas_y_terrenos,Tonalá,Renta,Casas,https://www.lamudi.com.mx/jalisco/tonala-1/casa/for-rent/
+Casas_y_terrenos,Tonalá,Venta,Consultorios,https://www.lamudi.com.mx/jalisco/tonala-1/offices/medico-consulting/for-sale/
+Casas_y_terrenos,Tonalá,Renta,Consultorios,https://www.lamudi.com.mx/jalisco/tonala-1/offices/medico-consulting/for-rent/
+Casas_y_terrenos,Tonalá,Venta,Departamentos,https://www.lamudi.com.mx/jalisco/tonala-1/departamento/for-sale/
+Casas_y_terrenos,Tonalá,Renta,Departamentos,https://www.lamudi.com.mx/jalisco/tonala-1/departamento/for-rent/
+Casas_y_terrenos,Tonalá,Venta,Edificios,https://www.lamudi.com.mx/jalisco/tonala-1/offices/edificio/for-sale/
+Casas_y_terrenos,Tonalá,Renta,Edificios,https://www.lamudi.com.mx/jalisco/tonala-1/offices/edificio/for-rent/
+Casas_y_terrenos,Tonalá,Venta,Locales en Centros Comerciales,https://www.lamudi.com.mx/jalisco/tonala-1/comercial/comercial-agricultura/for-sale/
+Casas_y_terrenos,Tonalá,Renta,Locales en Centros Comerciales,https://www.lamudi.com.mx/jalisco/tonala-1/comercial/comercial-agricultura/for-rent/
+Casas_y_terrenos,Tonalá,Venta,Locales Retail,https://www.lamudi.com.mx/jalisco/tonala-1/comercial/venta-al-por-menor/for-sale/
+Casas_y_terrenos,Tonalá,Renta,Locales Retail,https://www.lamudi.com.mx/jalisco/tonala-1/comercial/venta-al-por-menor/for-rent/
+Casas_y_terrenos,Tonalá,Venta,Naves/Bodegas,https://www.lamudi.com.mx/jalisco/tonala-1/comercial/industria-almacen/for-sale/
+Casas_y_terrenos,Tonalá,Renta,Naves/Bodegas,https://www.lamudi.com.mx/jalisco/tonala-1/comercial/industria-almacen/for-rent/
+Casas_y_terrenos,Tonalá,Venta,Oficinas,https://www.lamudi.com.mx/jalisco/tonala-1/offices/for-sale/
+Casas_y_terrenos,Tonalá,Renta,Oficinas,https://www.lamudi.com.mx/jalisco/tonala-1/offices/for-rent/
+Casas_y_terrenos,Tonalá,Venta,Terrenos,https://www.lamudi.com.mx/jalisco/tonala-1/terreno/for-sale/
+Casas_y_terrenos,Tonalá,Renta,Terrenos,https://www.lamudi.com.mx/jalisco/tonala-1/terreno/for-rent/
+Casas_y_terrenos,Zapopan,Venta,Casas,https://www.lamudi.com.mx/jalisco/zapopan/casa/for-sale/
+Casas_y_terrenos,Zapopan,Renta,Casas,https://www.lamudi.com.mx/jalisco/zapopan/casa/for-rent/
+Casas_y_terrenos,Zapopan,Venta,Consultorios,https://www.lamudi.com.mx/jalisco/zapopan/offices/medico-consulting/for-sale/
+Casas_y_terrenos,Zapopan,Renta,Consultorios,https://www.lamudi.com.mx/jalisco/zapopan/offices/medico-consulting/for-rent/
+Casas_y_terrenos,Zapopan,Venta,Departamentos,https://www.lamudi.com.mx/jalisco/zapopan/departamento/for-sale/
+Casas_y_terrenos,Zapopan,Renta,Departamentos,https://www.lamudi.com.mx/jalisco/zapopan/departamento/for-rent/
+Casas_y_terrenos,Zapopan,Venta,Edificios,https://www.lamudi.com.mx/jalisco/zapopan/offices/edificio/for-sale/
+Casas_y_terrenos,Zapopan,Renta,Edificios,https://www.lamudi.com.mx/jalisco/zapopan/offices/edificio/for-rent/
+Casas_y_terrenos,Zapopan,Venta,Locales en Centros Comerciales,https://www.lamudi.com.mx/jalisco/zapopan/comercial/comercial-agricultura/for-sale/
+Casas_y_terrenos,Zapopan,Renta,Locales en Centros Comerciales,https://www.lamudi.com.mx/jalisco/zapopan/comercial/comercial-agricultura/for-rent/
+Casas_y_terrenos,Zapopan,Venta,Locales Retail,https://www.lamudi.com.mx/jalisco/zapopan/comercial/venta-al-por-menor/for-sale/
+Casas_y_terrenos,Zapopan,Renta,Locales Retail,https://www.lamudi.com.mx/jalisco/zapopan/comercial/venta-al-por-menor/for-rent/
+Casas_y_terrenos,Zapopan,Venta,Naves/Bodegas,https://www.lamudi.com.mx/jalisco/zapopan/comercial/industria-almacen/for-sale/
+Casas_y_terrenos,Zapopan,Renta,Naves/Bodegas,https://www.lamudi.com.mx/jalisco/zapopan/comercial/industria-almacen/for-rent/
+Casas_y_terrenos,Zapopan,Venta,Oficinas,https://www.lamudi.com.mx/jalisco/zapopan/offices/for-sale/
+Casas_y_terrenos,Zapopan,Renta,Oficinas,https://www.lamudi.com.mx/jalisco/zapopan/offices/for-rent/
+Casas_y_terrenos,Zapopan,Venta,Terrenos,https://www.lamudi.com.mx/jalisco/zapopan/terreno/for-sale/
+Casas_y_terrenos,Zapopan,Renta,Terrenos,https://www.lamudi.com.mx/jalisco/zapopan/terreno/for-rent/
+Casas_y_terrenos,Zapotlanejo,Venta,Casas,https://www.lamudi.com.mx/jalisco/zapotlanejo/casa/for-sale/
+Casas_y_terrenos,Zapotlanejo,Renta,Casas,https://www.lamudi.com.mx/jalisco/zapotlanejo/casa/for-rent/
+Casas_y_terrenos,Zapotlanejo,Venta,Consultorios,https://www.lamudi.com.mx/jalisco/zapotlanejo/offices/medico-consulting/for-sale/
+Casas_y_terrenos,Zapotlanejo,Renta,Consultorios,https://www.lamudi.com.mx/jalisco/zapotlanejo/offices/medico-consulting/for-rent/
+Casas_y_terrenos,Zapotlanejo,Venta,Departamentos,https://www.lamudi.com.mx/jalisco/zapotlanejo/departamento/for-sale/
+Casas_y_terrenos,Zapotlanejo,Renta,Departamentos,https://www.lamudi.com.mx/jalisco/zapotlanejo/departamento/for-rent/
+Casas_y_terrenos,Zapotlanejo,Venta,Edificios,https://www.lamudi.com.mx/jalisco/zapotlanejo/offices/edificio/for-sale/
+Casas_y_terrenos,Zapotlanejo,Renta,Edificios,https://www.lamudi.com.mx/jalisco/zapotlanejo/offices/edificio/for-rent/
+Casas_y_terrenos,Zapotlanejo,Venta,Locales en Centros Comerciales,https://www.lamudi.com.mx/jalisco/zapotlanejo/comercial/comercial-agricultura/for-sale/
+Casas_y_terrenos,Zapotlanejo,Renta,Locales en Centros Comerciales,https://www.lamudi.com.mx/jalisco/zapotlanejo/comercial/comercial-agricultura/for-rent/
+Casas_y_terrenos,Zapotlanejo,Venta,Locales Retail,https://www.lamudi.com.mx/jalisco/zapotlanejo/comercial/venta-al-por-menor/for-sale/
+Casas_y_terrenos,Zapotlanejo,Renta,Locales Retail,https://www.lamudi.com.mx/jalisco/zapotlanejo/comercial/venta-al-por-menor/for-rent/
+Casas_y_terrenos,Zapotlanejo,Venta,Naves/Bodegas,https://www.lamudi.com.mx/jalisco/zapotlanejo/comercial/industria-almacen/for-sale/
+Casas_y_terrenos,Zapotlanejo,Renta,Naves/Bodegas,https://www.lamudi.com.mx/jalisco/zapotlanejo/comercial/industria-almacen/for-rent/
+Casas_y_terrenos,Zapotlanejo,Venta,Oficinas,https://www.lamudi.com.mx/jalisco/zapotlanejo/offices/for-sale/
+Casas_y_terrenos,Zapotlanejo,Renta,Oficinas,https://www.lamudi.com.mx/jalisco/zapotlanejo/offices/for-rent/
+Casas_y_terrenos,Zapotlanejo,Venta,Terrenos,https://www.lamudi.com.mx/jalisco/zapotlanejo/terreno/for-sale/
+Casas_y_terrenos,Zapotlanejo,Renta,Terrenos,https://www.lamudi.com.mx/jalisco/zapotlanejo/terreno/for-rent/

--- a/URLs/mit_urls.csv
+++ b/URLs/mit_urls.csv
@@ -1,470 +1,469 @@
-# Formato: PaginaWeb,Ciudad,Operación,ProductoPaginaWeb,URL
-PaginaWeb,Ciudad,Operación,ProductoPaginaWeb,URL,ago25_2,sep25_1,sep25_2,oct25_1,oct25_2,nov25_1,nov25_2,dic25_1,dic25_2,ene25_1,ene25_2,feb25_1,feb25_2,mar25_1,mar25_2,abr25_1,abr25_2,may25_1,may25_2,jun25_1,jun25_2,jul25_1,jul25_2,ago25_1,ago25_2,sep25_1,sep25_2
-mitula,El Salto,Renta,Doctor office,https://casas.mitula.mx/casas/renta-doctor-office-el-salto,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Guadalajara,Renta,Doctor office,https://casas.mitula.mx/casas/renta-doctor-office-guadalajara,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,IxtlahuacÃ¡n de los membrillos,Renta,Doctor office,https://casas.mitula.mx/casas/renta-doctor-office-ixtlahuacan-de-los-membrillos,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,JuanacatlÃ¡n,Renta,Doctor office,https://casas.mitula.mx/casas/renta-doctor-office-juanacatlan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,San Pedro Tlaquepaque,Renta,Doctor office,https://casas.mitula.mx/casas/renta-doctor-office-san-pedro-tlaquepaque,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Tlajomulco de ZuÃ±iga,Renta,Doctor office,https://casas.mitula.mx/casas/renta-doctor-office-tlajomulco-de-zuniga,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,TonalÃ¡,Renta,Doctor office,https://casas.mitula.mx/casas/renta-doctor-office-tonala,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapopan,Renta,Doctor office,https://casas.mitula.mx/casas/renta-doctor-office-zapopan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapotlanejo,Renta,Doctor office,https://casas.mitula.mx/casas/renta-doctor-office-zapotlanejo,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,El Salto,Venta,Doctor office,https://casas.mitula.mx/casas/venta-doctor-office-el-salto,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Guadalajara,Venta,Doctor office,https://casas.mitula.mx/casas/venta-doctor-office-guadalajara,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,IxtlahuacÃ¡n de los membrillos,Venta,Doctor office,https://casas.mitula.mx/casas/venta-doctor-office-ixtlahuacan-de-los-membrillos,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,JuanacatlÃ¡n,Venta,Doctor office,https://casas.mitula.mx/casas/venta-doctor-office-juanacatlan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,San Pedro Tlaquepaque,Venta,Doctor office,https://casas.mitula.mx/casas/venta-doctor-office-san-pedro-tlaquepaque,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Tlajomulco de ZuÃ±iga,Venta,Doctor office,https://casas.mitula.mx/casas/venta-doctor-office-tlajomulco-de-zuniga,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,TonalÃ¡,Venta,Doctor office,https://casas.mitula.mx/casas/venta-doctor-office-tonala,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapopan,Venta,Doctor office,https://casas.mitula.mx/casas/venta-doctor-office-zapopan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapotlanejo,Venta,Doctor office,https://casas.mitula.mx/casas/venta-doctor-office-zapotlanejo,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,El Salto,Renta,Casa,https://casas.mitula.mx/casas/renta-casas-el-salto,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Guadalajara,Renta,Casa,https://casas.mitula.mx/casas/renta-casas-guadalajara,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,IxtlahuacÃ¡n de los membrillos,Renta,Casa,https://casas.mitula.mx/casas/renta-casas-ixtlahuacan-de-los-membrillos,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,JuanacatlÃ¡n,Renta,Casa,https://casas.mitula.mx/casas/renta-casas-juanacatlan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,San Pedro Tlaquepaque,Renta,Casa,https://casas.mitula.mx/casas/renta-casas-san-pedro-tlaquepaque,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Tlajomulco de ZuÃ±iga,Renta,Casa,https://casas.mitula.mx/casas/renta-casas-tlajomulco-de-zuniga,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,TonalÃ¡,Renta,Casa,https://casas.mitula.mx/casas/renta-casas-tonala,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapopan,Renta,Casa,https://casas.mitula.mx/casas/renta-casas-zapopan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapotlanejo,Renta,Casa,https://casas.mitula.mx/casas/renta-casas-zapotlanejo,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,El Salto,Venta,Casa,https://casas.mitula.mx/casas/venta-casas-el-salto,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Guadalajara,Venta,Casa,https://casas.mitula.mx/casas/venta-casas-guadalajara,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,IxtlahuacÃ¡n de los membrillos,Venta,Casa,https://casas.mitula.mx/casas/venta-casas-ixtlahuacan-de-los-membrillos,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,JuanacatlÃ¡n,Venta,Casa,https://casas.mitula.mx/casas/venta-casas-juanacatlan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,San Pedro Tlaquepaque,Venta,Casa,https://casas.mitula.mx/casas/venta-casas-san-pedro-tlaquepaque,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Tlajomulco de ZuÃ±iga,Venta,Casa,https://casas.mitula.mx/casas/venta-casas-tlajomulco-de-zuniga,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,TonalÃ¡,Venta,Casa,https://casas.mitula.mx/casas/venta-casas-tonala,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapopan,Venta,Casa,https://casas.mitula.mx/casas/venta-casas-zapopan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapotlanejo,Venta,Casa,https://casas.mitula.mx/casas/venta-casas-zapotlanejo,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,El Salto,Renta,Ãtico,https://casas.mitula.mx/casas/renta-aticos-el-salto,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Guadalajara,Renta,Ãtico,https://casas.mitula.mx/casas/renta-aticos-guadalajara,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,IxtlahuacÃ¡n de los membrillos,Renta,Ãtico,https://casas.mitula.mx/casas/renta-aticos-ixtlahuacan-de-los-membrillos,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,JuanacatlÃ¡n,Renta,Ãtico,https://casas.mitula.mx/casas/renta-aticos-juanacatlan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,San Pedro Tlaquepaque,Renta,Ãtico,https://casas.mitula.mx/casas/renta-aticos-san-pedro-tlaquepaque,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Tlajomulco de ZuÃ±iga,Renta,Ãtico,https://casas.mitula.mx/casas/renta-aticos-tlajomulco-de-zuniga,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,TonalÃ¡,Renta,Ãtico,https://casas.mitula.mx/casas/renta-aticos-tonala,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapopan,Renta,Ãtico,https://casas.mitula.mx/casas/renta-aticos-zapopan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapotlanejo,Renta,Ãtico,https://casas.mitula.mx/casas/renta-aticos-zapotlanejo,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,El Salto,Venta,Ãtico,https://casas.mitula.mx/casas/venta-aticos-el-salto,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Guadalajara,Venta,Ãtico,https://casas.mitula.mx/casas/venta-aticos-guadalajara,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,IxtlahuacÃ¡n de los membrillos,Venta,Ãtico,https://casas.mitula.mx/casas/venta-aticos-ixtlahuacan-de-los-membrillos,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,JuanacatlÃ¡n,Venta,Ãtico,https://casas.mitula.mx/casas/venta-aticos-juanacatlan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,San Pedro Tlaquepaque,Venta,Ãtico,https://casas.mitula.mx/casas/venta-aticos-san-pedro-tlaquepaque,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Tlajomulco de ZuÃ±iga,Venta,Ãtico,https://casas.mitula.mx/casas/venta-aticos-tlajomulco-de-zuniga,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,TonalÃ¡,Venta,Ãtico,https://casas.mitula.mx/casas/venta-aticos-tonala,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapopan,Venta,Ãtico,https://casas.mitula.mx/casas/venta-aticos-zapopan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapotlanejo,Venta,Ãtico,https://casas.mitula.mx/casas/venta-aticos-zapotlanejo,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,El Salto,Renta,Bodega,https://casas.mitula.mx/casas/renta-bodegas-el-salto,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Guadalajara,Renta,Bodega,https://casas.mitula.mx/casas/renta-bodegas-guadalajara,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,IxtlahuacÃ¡n de los membrillos,Renta,Bodega,https://casas.mitula.mx/casas/renta-bodegas-ixtlahuacan-de-los-membrillos,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,JuanacatlÃ¡n,Renta,Bodega,https://casas.mitula.mx/casas/renta-bodegas-juanacatlan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,San Pedro Tlaquepaque,Renta,Bodega,https://casas.mitula.mx/casas/renta-bodegas-san-pedro-tlaquepaque,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Tlajomulco de ZuÃ±iga,Renta,Bodega,https://casas.mitula.mx/casas/renta-bodegas-tlajomulco-de-zuniga,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,TonalÃ¡,Renta,Bodega,https://casas.mitula.mx/casas/renta-bodegas-tonala,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapopan,Renta,Bodega,https://casas.mitula.mx/casas/renta-bodegas-zapopan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapotlanejo,Renta,Bodega,https://casas.mitula.mx/casas/renta-bodegas-zapotlanejo,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,El Salto,Venta,Bodega,https://casas.mitula.mx/casas/venta-bodegas-el-salto,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Guadalajara,Venta,Bodega,https://casas.mitula.mx/casas/venta-bodegas-guadalajara,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,IxtlahuacÃ¡n de los membrillos,Venta,Bodega,https://casas.mitula.mx/casas/venta-bodegas-ixtlahuacan-de-los-membrillos,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,JuanacatlÃ¡n,Venta,Bodega,https://casas.mitula.mx/casas/venta-bodegas-juanacatlan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,San Pedro Tlaquepaque,Venta,Bodega,https://casas.mitula.mx/casas/venta-bodegas-san-pedro-tlaquepaque,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Tlajomulco de ZuÃ±iga,Venta,Bodega,https://casas.mitula.mx/casas/venta-bodegas-tlajomulco-de-zuniga,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,TonalÃ¡,Venta,Bodega,https://casas.mitula.mx/casas/venta-bodegas-tonala,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapopan,Venta,Bodega,https://casas.mitula.mx/casas/venta-bodegas-zapopan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapotlanejo,Venta,Bodega,https://casas.mitula.mx/casas/venta-bodegas-zapotlanejo,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,El Salto,Renta,Bungalow,https://casas.mitula.mx/casas/renta-bungalows-el-salto,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Guadalajara,Renta,Bungalow,https://casas.mitula.mx/casas/renta-bungalows-guadalajara,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,IxtlahuacÃ¡n de los membrillos,Renta,Bungalow,https://casas.mitula.mx/casas/renta-bungalows-ixtlahuacan-de-los-membrillos,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,JuanacatlÃ¡n,Renta,Bungalow,https://casas.mitula.mx/casas/renta-bungalows-juanacatlan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,San Pedro Tlaquepaque,Renta,Bungalow,https://casas.mitula.mx/casas/renta-bungalows-san-pedro-tlaquepaque,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Tlajomulco de ZuÃ±iga,Renta,Bungalow,https://casas.mitula.mx/casas/renta-bungalows-tlajomulco-de-zuniga,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,TonalÃ¡,Renta,Bungalow,https://casas.mitula.mx/casas/renta-bungalows-tonala,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapopan,Renta,Bungalow,https://casas.mitula.mx/casas/renta-bungalows-zapopan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapotlanejo,Renta,Bungalow,https://casas.mitula.mx/casas/renta-bungalows-zapotlanejo,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,El Salto,Venta,Bungalow,https://casas.mitula.mx/casas/venta-bungalows-el-salto,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Guadalajara,Venta,Bungalow,https://casas.mitula.mx/casas/venta-bungalows-guadalajara,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,IxtlahuacÃ¡n de los membrillos,Venta,Bungalow,https://casas.mitula.mx/casas/venta-bungalows-ixtlahuacan-de-los-membrillos,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,JuanacatlÃ¡n,Venta,Bungalow,https://casas.mitula.mx/casas/venta-bungalows-juanacatlan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,San Pedro Tlaquepaque,Venta,Bungalow,https://casas.mitula.mx/casas/venta-bungalows-san-pedro-tlaquepaque,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Tlajomulco de ZuÃ±iga,Venta,Bungalow,https://casas.mitula.mx/casas/venta-bungalows-tlajomulco-de-zuniga,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,TonalÃ¡,Venta,Bungalow,https://casas.mitula.mx/casas/venta-bungalows-tonala,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapopan,Venta,Bungalow,https://casas.mitula.mx/casas/venta-bungalows-zapopan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapotlanejo,Venta,Bungalow,https://casas.mitula.mx/casas/venta-bungalows-zapotlanejo,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,El Salto,Renta,Casa en Condominio,https://casas.mitula.mx/casas/renta-casas-en-condominio-el-salto,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Guadalajara,Renta,Casa en Condominio,https://casas.mitula.mx/casas/renta-casas-en-condominio-guadalajara,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,IxtlahuacÃ¡n de los membrillos,Renta,Casa en Condominio,https://casas.mitula.mx/casas/renta-casas-en-condominio-ixtlahuacan-de-los-membrillos,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,JuanacatlÃ¡n,Renta,Casa en Condominio,https://casas.mitula.mx/casas/renta-casas-en-condominio-juanacatlan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,San Pedro Tlaquepaque,Renta,Casa en Condominio,https://casas.mitula.mx/casas/renta-casas-en-condominio-san-pedro-tlaquepaque,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Tlajomulco de ZuÃ±iga,Renta,Casa en Condominio,https://casas.mitula.mx/casas/renta-casas-en-condominio-tlajomulco-de-zuniga,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,TonalÃ¡,Renta,Casa en Condominio,https://casas.mitula.mx/casas/renta-casas-en-condominio-tonala,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapopan,Renta,Casa en Condominio,https://casas.mitula.mx/casas/renta-casas-en-condominio-zapopan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapotlanejo,Renta,Casa en Condominio,https://casas.mitula.mx/casas/renta-casas-en-condominio-zapotlanejo,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,El Salto,Venta,Casa en Condominio,https://casas.mitula.mx/casas/venta-casas-en-condominio-el-salto,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Guadalajara,Venta,Casa en Condominio,https://casas.mitula.mx/casas/venta-casas-en-condominio-guadalajara,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,IxtlahuacÃ¡n de los membrillos,Venta,Casa en Condominio,https://casas.mitula.mx/casas/venta-casas-en-condominio-ixtlahuacan-de-los-membrillos,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,JuanacatlÃ¡n,Venta,Casa en Condominio,https://casas.mitula.mx/casas/venta-casas-en-condominio-juanacatlan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,San Pedro Tlaquepaque,Venta,Casa en Condominio,https://casas.mitula.mx/casas/venta-casas-en-condominio-san-pedro-tlaquepaque,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Tlajomulco de ZuÃ±iga,Venta,Casa en Condominio,https://casas.mitula.mx/casas/venta-casas-en-condominio-tlajomulco-de-zuniga,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,TonalÃ¡,Venta,Casa en Condominio,https://casas.mitula.mx/casas/venta-casas-en-condominio-tonala,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapopan,Venta,Casa en Condominio,https://casas.mitula.mx/casas/venta-casas-en-condominio-zapopan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapotlanejo,Venta,Casa en Condominio,https://casas.mitula.mx/casas/venta-casas-en-condominio-zapotlanejo,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,El Salto,Renta,Casa en Fraccionamiento,https://casas.mitula.mx/casas/renta-casas-en-fraccionamiento-el-salto,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Guadalajara,Renta,Casa en Fraccionamiento,https://casas.mitula.mx/casas/renta-casas-en-fraccionamiento-guadalajara,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,IxtlahuacÃ¡n de los membrillos,Renta,Casa en Fraccionamiento,https://casas.mitula.mx/casas/renta-casas-en-fraccionamiento-ixtlahuacan-de-los-membrillos,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,JuanacatlÃ¡n,Renta,Casa en Fraccionamiento,https://casas.mitula.mx/casas/renta-casas-en-fraccionamiento-juanacatlan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,San Pedro Tlaquepaque,Renta,Casa en Fraccionamiento,https://casas.mitula.mx/casas/renta-casas-en-fraccionamiento-san-pedro-tlaquepaque,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Tlajomulco de ZuÃ±iga,Renta,Casa en Fraccionamiento,https://casas.mitula.mx/casas/renta-casas-en-fraccionamiento-tlajomulco-de-zuniga,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,TonalÃ¡,Renta,Casa en Fraccionamiento,https://casas.mitula.mx/casas/renta-casas-en-fraccionamiento-tonala,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapopan,Renta,Casa en Fraccionamiento,https://casas.mitula.mx/casas/renta-casas-en-fraccionamiento-zapopan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapotlanejo,Renta,Casa en Fraccionamiento,https://casas.mitula.mx/casas/renta-casas-en-fraccionamiento-zapotlanejo,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,El Salto,Venta,Casa en Fraccionamiento,https://casas.mitula.mx/casas/venta-casas-en-fraccionamiento-el-salto,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Guadalajara,Venta,Casa en Fraccionamiento,https://casas.mitula.mx/casas/venta-casas-en-fraccionamiento-guadalajara,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,IxtlahuacÃ¡n de los membrillos,Venta,Casa en Fraccionamiento,https://casas.mitula.mx/casas/venta-casas-en-fraccionamiento-ixtlahuacan-de-los-membrillos,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,JuanacatlÃ¡n,Venta,Casa en Fraccionamiento,https://casas.mitula.mx/casas/venta-casas-en-fraccionamiento-juanacatlan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,San Pedro Tlaquepaque,Venta,Casa en Fraccionamiento,https://casas.mitula.mx/casas/venta-casas-en-fraccionamiento-san-pedro-tlaquepaque,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Tlajomulco de ZuÃ±iga,Venta,Casa en Fraccionamiento,https://casas.mitula.mx/casas/venta-casas-en-fraccionamiento-tlajomulco-de-zuniga,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,TonalÃ¡,Venta,Casa en Fraccionamiento,https://casas.mitula.mx/casas/venta-casas-en-fraccionamiento-tonala,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapopan,Venta,Casa en Fraccionamiento,https://casas.mitula.mx/casas/venta-casas-en-fraccionamiento-zapopan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapotlanejo,Venta,Casa en Fraccionamiento,https://casas.mitula.mx/casas/venta-casas-en-fraccionamiento-zapotlanejo,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,El Salto,Renta,Condominio Horizontal,https://casas.mitula.mx/casas/renta-condominio-horizontal-el-salto,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Guadalajara,Renta,Condominio Horizontal,https://casas.mitula.mx/casas/renta-condominio-horizontal-guadalajara,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,IxtlahuacÃ¡n de los membrillos,Renta,Condominio Horizontal,https://casas.mitula.mx/casas/renta-condominio-horizontal-ixtlahuacan-de-los-membrillos,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,JuanacatlÃ¡n,Renta,Condominio Horizontal,https://casas.mitula.mx/casas/renta-condominio-horizontal-juanacatlan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,San Pedro Tlaquepaque,Renta,Condominio Horizontal,https://casas.mitula.mx/casas/renta-condominio-horizontal-san-pedro-tlaquepaque,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Tlajomulco de ZuÃ±iga,Renta,Condominio Horizontal,https://casas.mitula.mx/casas/renta-condominio-horizontal-tlajomulco-de-zuniga,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,TonalÃ¡,Renta,Condominio Horizontal,https://casas.mitula.mx/casas/renta-condominio-horizontal-tonala,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapopan,Renta,Condominio Horizontal,https://casas.mitula.mx/casas/renta-condominio-horizontal-zapopan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapotlanejo,Renta,Condominio Horizontal,https://casas.mitula.mx/casas/renta-condominio-horizontal-zapotlanejo,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,El Salto,Venta,Condominio Horizontal,https://casas.mitula.mx/casas/venta-condominio-horizontal-el-salto,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Guadalajara,Venta,Condominio Horizontal,https://casas.mitula.mx/casas/venta-condominio-horizontal-guadalajara,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,IxtlahuacÃ¡n de los membrillos,Venta,Condominio Horizontal,https://casas.mitula.mx/casas/venta-condominio-horizontal-ixtlahuacan-de-los-membrillos,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,JuanacatlÃ¡n,Venta,Condominio Horizontal,https://casas.mitula.mx/casas/venta-condominio-horizontal-juanacatlan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,San Pedro Tlaquepaque,Venta,Condominio Horizontal,https://casas.mitula.mx/casas/venta-condominio-horizontal-san-pedro-tlaquepaque,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Tlajomulco de ZuÃ±iga,Venta,Condominio Horizontal,https://casas.mitula.mx/casas/venta-condominio-horizontal-tlajomulco-de-zuniga,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,TonalÃ¡,Venta,Condominio Horizontal,https://casas.mitula.mx/casas/venta-condominio-horizontal-tonala,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapopan,Venta,Condominio Horizontal,https://casas.mitula.mx/casas/venta-condominio-horizontal-zapopan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapotlanejo,Venta,Condominio Horizontal,https://casas.mitula.mx/casas/venta-condominio-horizontal-zapotlanejo,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,El Salto,Renta,Cuarto,https://casas.mitula.mx/casas/renta-cuartos-el-salto,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Guadalajara,Renta,Cuarto,https://casas.mitula.mx/casas/renta-cuartos-guadalajara,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,IxtlahuacÃ¡n de los membrillos,Renta,Cuarto,https://casas.mitula.mx/casas/renta-cuartos-ixtlahuacan-de-los-membrillos,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,JuanacatlÃ¡n,Renta,Cuarto,https://casas.mitula.mx/casas/renta-cuartos-juanacatlan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,San Pedro Tlaquepaque,Renta,Cuarto,https://casas.mitula.mx/casas/renta-cuartos-san-pedro-tlaquepaque,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Tlajomulco de ZuÃ±iga,Renta,Cuarto,https://casas.mitula.mx/casas/renta-cuartos-tlajomulco-de-zuniga,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,TonalÃ¡,Renta,Cuarto,https://casas.mitula.mx/casas/renta-cuartos-tonala,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapopan,Renta,Cuarto,https://casas.mitula.mx/casas/renta-cuartos-zapopan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapotlanejo,Renta,Cuarto,https://casas.mitula.mx/casas/renta-cuartos-zapotlanejo,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,El Salto,Venta,Cuarto,https://casas.mitula.mx/casas/venta-cuartos-el-salto,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Guadalajara,Venta,Cuarto,https://casas.mitula.mx/casas/venta-cuartos-guadalajara,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,IxtlahuacÃ¡n de los membrillos,Venta,Cuarto,https://casas.mitula.mx/casas/venta-cuartos-ixtlahuacan-de-los-membrillos,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,JuanacatlÃ¡n,Venta,Cuarto,https://casas.mitula.mx/casas/venta-cuartos-juanacatlan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,San Pedro Tlaquepaque,Venta,Cuarto,https://casas.mitula.mx/casas/venta-cuartos-san-pedro-tlaquepaque,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Tlajomulco de ZuÃ±iga,Venta,Cuarto,https://casas.mitula.mx/casas/venta-cuartos-tlajomulco-de-zuniga,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,TonalÃ¡,Venta,Cuarto,https://casas.mitula.mx/casas/venta-cuartos-tonala,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapopan,Venta,Cuarto,https://casas.mitula.mx/casas/venta-cuartos-zapopan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapotlanejo,Venta,Cuarto,https://casas.mitula.mx/casas/venta-cuartos-zapotlanejo,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,El Salto,Renta,DÃºplex,https://casas.mitula.mx/casas/renta-duplex-el-salto,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Guadalajara,Renta,DÃºplex,https://casas.mitula.mx/casas/renta-duplex-guadalajara,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,IxtlahuacÃ¡n de los membrillos,Renta,DÃºplex,https://casas.mitula.mx/casas/renta-duplex-ixtlahuacan-de-los-membrillos,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,JuanacatlÃ¡n,Renta,DÃºplex,https://casas.mitula.mx/casas/renta-duplex-juanacatlan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,San Pedro Tlaquepaque,Renta,DÃºplex,https://casas.mitula.mx/casas/renta-duplex-san-pedro-tlaquepaque,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Tlajomulco de ZuÃ±iga,Renta,DÃºplex,https://casas.mitula.mx/casas/renta-duplex-tlajomulco-de-zuniga,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,TonalÃ¡,Renta,DÃºplex,https://casas.mitula.mx/casas/renta-duplex-tonala,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapopan,Renta,DÃºplex,https://casas.mitula.mx/casas/renta-duplex-zapopan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapotlanejo,Renta,DÃºplex,https://casas.mitula.mx/casas/renta-duplex-zapotlanejo,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,El Salto,Venta,DÃºplex,https://casas.mitula.mx/casas/venta-duplex-el-salto,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Guadalajara,Venta,DÃºplex,https://casas.mitula.mx/casas/venta-duplex-guadalajara,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,IxtlahuacÃ¡n de los membrillos,Venta,DÃºplex,https://casas.mitula.mx/casas/venta-duplex-ixtlahuacan-de-los-membrillos,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,JuanacatlÃ¡n,Venta,DÃºplex,https://casas.mitula.mx/casas/venta-duplex-juanacatlan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,San Pedro Tlaquepaque,Venta,DÃºplex,https://casas.mitula.mx/casas/venta-duplex-san-pedro-tlaquepaque,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Tlajomulco de ZuÃ±iga,Venta,DÃºplex,https://casas.mitula.mx/casas/venta-duplex-tlajomulco-de-zuniga,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,TonalÃ¡,Venta,DÃºplex,https://casas.mitula.mx/casas/venta-duplex-tonala,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapopan,Venta,DÃºplex,https://casas.mitula.mx/casas/venta-duplex-zapopan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapotlanejo,Venta,DÃºplex,https://casas.mitula.mx/casas/venta-duplex-zapotlanejo,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,El Salto,Renta,Departamento,https://casas.mitula.mx/casas/renta-departamentos-el-salto,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Guadalajara,Renta,Departamento,https://casas.mitula.mx/casas/renta-departamentos-guadalajara,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,IxtlahuacÃ¡n de los membrillos,Renta,Departamento,https://casas.mitula.mx/casas/renta-departamentos-ixtlahuacan-de-los-membrillos,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,JuanacatlÃ¡n,Renta,Departamento,https://casas.mitula.mx/casas/renta-departamentos-juanacatlan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,San Pedro Tlaquepaque,Renta,Departamento,https://casas.mitula.mx/casas/renta-departamentos-san-pedro-tlaquepaque,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Tlajomulco de ZuÃ±iga,Renta,Departamento,https://casas.mitula.mx/casas/renta-departamentos-tlajomulco-de-zuniga,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,TonalÃ¡,Renta,Departamento,https://casas.mitula.mx/casas/renta-departamentos-tonala,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapopan,Renta,Departamento,https://casas.mitula.mx/casas/renta-departamentos-zapopan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapotlanejo,Renta,Departamento,https://casas.mitula.mx/casas/renta-departamentos-zapotlanejo,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,El Salto,Venta,Departamento,https://casas.mitula.mx/casas/venta-departamentos-el-salto,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Guadalajara,Venta,Departamento,https://casas.mitula.mx/casas/venta-departamentos-guadalajara,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,IxtlahuacÃ¡n de los membrillos,Venta,Departamento,https://casas.mitula.mx/casas/venta-departamentos-ixtlahuacan-de-los-membrillos,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,JuanacatlÃ¡n,Venta,Departamento,https://casas.mitula.mx/casas/venta-departamentos-juanacatlan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,San Pedro Tlaquepaque,Venta,Departamento,https://casas.mitula.mx/casas/venta-departamentos-san-pedro-tlaquepaque,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Tlajomulco de ZuÃ±iga,Venta,Departamento,https://casas.mitula.mx/casas/venta-departamentos-tlajomulco-de-zuniga,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,TonalÃ¡,Venta,Departamento,https://casas.mitula.mx/casas/venta-departamentos-tonala,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapopan,Venta,Departamento,https://casas.mitula.mx/casas/venta-departamentos-zapopan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapotlanejo,Venta,Departamento,https://casas.mitula.mx/casas/venta-departamentos-zapotlanejo,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,El Salto,Renta,DesvÃ¡n,https://casas.mitula.mx/casas/renta-desvanes-el-salto,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Guadalajara,Renta,DesvÃ¡n,https://casas.mitula.mx/casas/renta-desvanes-guadalajara,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,IxtlahuacÃ¡n de los membrillos,Renta,DesvÃ¡n,https://casas.mitula.mx/casas/renta-desvanes-ixtlahuacan-de-los-membrillos,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,JuanacatlÃ¡n,Renta,DesvÃ¡n,https://casas.mitula.mx/casas/renta-desvanes-juanacatlan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,San Pedro Tlaquepaque,Renta,DesvÃ¡n,https://casas.mitula.mx/casas/renta-desvanes-san-pedro-tlaquepaque,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Tlajomulco de ZuÃ±iga,Renta,DesvÃ¡n,https://casas.mitula.mx/casas/renta-desvanes-tlajomulco-de-zuniga,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,TonalÃ¡,Renta,DesvÃ¡n,https://casas.mitula.mx/casas/renta-desvanes-tonala,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapopan,Renta,DesvÃ¡n,https://casas.mitula.mx/casas/renta-desvanes-zapopan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapotlanejo,Renta,DesvÃ¡n,https://casas.mitula.mx/casas/renta-desvanes-zapotlanejo,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,El Salto,Venta,DesvÃ¡n,https://casas.mitula.mx/casas/venta-desvanes-el-salto,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Guadalajara,Venta,DesvÃ¡n,https://casas.mitula.mx/casas/venta-desvanes-guadalajara,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,IxtlahuacÃ¡n de los membrillos,Venta,DesvÃ¡n,https://casas.mitula.mx/casas/venta-desvanes-ixtlahuacan-de-los-membrillos,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,JuanacatlÃ¡n,Venta,DesvÃ¡n,https://casas.mitula.mx/casas/venta-desvanes-juanacatlan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,San Pedro Tlaquepaque,Venta,DesvÃ¡n,https://casas.mitula.mx/casas/venta-desvanes-san-pedro-tlaquepaque,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Tlajomulco de ZuÃ±iga,Venta,DesvÃ¡n,https://casas.mitula.mx/casas/venta-desvanes-tlajomulco-de-zuniga,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,TonalÃ¡,Venta,DesvÃ¡n,https://casas.mitula.mx/casas/venta-desvanes-tonala,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapopan,Venta,DesvÃ¡n,https://casas.mitula.mx/casas/venta-desvanes-zapopan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapotlanejo,Venta,DesvÃ¡n,https://casas.mitula.mx/casas/venta-desvanes-zapotlanejo,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,El Salto,Renta,Edificio,https://casas.mitula.mx/casas/renta-edificios-el-salto,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Guadalajara,Renta,Edificio,https://casas.mitula.mx/casas/renta-edificios-guadalajara,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,IxtlahuacÃ¡n de los membrillos,Renta,Edificio,https://casas.mitula.mx/casas/renta-edificios-ixtlahuacan-de-los-membrillos,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,JuanacatlÃ¡n,Renta,Edificio,https://casas.mitula.mx/casas/renta-edificios-juanacatlan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,San Pedro Tlaquepaque,Renta,Edificio,https://casas.mitula.mx/casas/renta-edificios-san-pedro-tlaquepaque,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Tlajomulco de ZuÃ±iga,Renta,Edificio,https://casas.mitula.mx/casas/renta-edificios-tlajomulco-de-zuniga,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,TonalÃ¡,Renta,Edificio,https://casas.mitula.mx/casas/renta-edificios-tonala,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapopan,Renta,Edificio,https://casas.mitula.mx/casas/renta-edificios-zapopan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapotlanejo,Renta,Edificio,https://casas.mitula.mx/casas/renta-edificios-zapotlanejo,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,El Salto,Venta,Edificio,https://casas.mitula.mx/casas/venta-edificios-el-salto,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Guadalajara,Venta,Edificio,https://casas.mitula.mx/casas/venta-edificios-guadalajara,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,IxtlahuacÃ¡n de los membrillos,Venta,Edificio,https://casas.mitula.mx/casas/venta-edificios-ixtlahuacan-de-los-membrillos,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,JuanacatlÃ¡n,Venta,Edificio,https://casas.mitula.mx/casas/venta-edificios-juanacatlan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,San Pedro Tlaquepaque,Venta,Edificio,https://casas.mitula.mx/casas/venta-edificios-san-pedro-tlaquepaque,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Tlajomulco de ZuÃ±iga,Venta,Edificio,https://casas.mitula.mx/casas/venta-edificios-tlajomulco-de-zuniga,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,TonalÃ¡,Venta,Edificio,https://casas.mitula.mx/casas/venta-edificios-tonala,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapopan,Venta,Edificio,https://casas.mitula.mx/casas/venta-edificios-zapopan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapotlanejo,Venta,Edificio,https://casas.mitula.mx/casas/venta-edificios-zapotlanejo,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,El Salto,Renta,Estudio,https://casas.mitula.mx/casas/renta-estudios-el-salto,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Guadalajara,Renta,Estudio,https://casas.mitula.mx/casas/renta-estudios-guadalajara,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,IxtlahuacÃ¡n de los membrillos,Renta,Estudio,https://casas.mitula.mx/casas/renta-estudios-ixtlahuacan-de-los-membrillos,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,JuanacatlÃ¡n,Renta,Estudio,https://casas.mitula.mx/casas/renta-estudios-juanacatlan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,San Pedro Tlaquepaque,Renta,Estudio,https://casas.mitula.mx/casas/renta-estudios-san-pedro-tlaquepaque,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Tlajomulco de ZuÃ±iga,Renta,Estudio,https://casas.mitula.mx/casas/renta-estudios-tlajomulco-de-zuniga,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,TonalÃ¡,Renta,Estudio,https://casas.mitula.mx/casas/renta-estudios-tonala,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapopan,Renta,Estudio,https://casas.mitula.mx/casas/renta-estudios-zapopan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapotlanejo,Renta,Estudio,https://casas.mitula.mx/casas/renta-estudios-zapotlanejo,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,El Salto,Venta,Estudio,https://casas.mitula.mx/casas/venta-estudios-el-salto,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Guadalajara,Venta,Estudio,https://casas.mitula.mx/casas/venta-estudios-guadalajara,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,IxtlahuacÃ¡n de los membrillos,Venta,Estudio,https://casas.mitula.mx/casas/venta-estudios-ixtlahuacan-de-los-membrillos,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,JuanacatlÃ¡n,Venta,Estudio,https://casas.mitula.mx/casas/venta-estudios-juanacatlan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,San Pedro Tlaquepaque,Venta,Estudio,https://casas.mitula.mx/casas/venta-estudios-san-pedro-tlaquepaque,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Tlajomulco de ZuÃ±iga,Venta,Estudio,https://casas.mitula.mx/casas/venta-estudios-tlajomulco-de-zuniga,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,TonalÃ¡,Venta,Estudio,https://casas.mitula.mx/casas/venta-estudios-tonala,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapopan,Venta,Estudio,https://casas.mitula.mx/casas/venta-estudios-zapopan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapotlanejo,Venta,Estudio,https://casas.mitula.mx/casas/venta-estudios-zapotlanejo,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,El Salto,Renta,Hacienda,https://casas.mitula.mx/casas/renta-haciendas-el-salto,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Guadalajara,Renta,Hacienda,https://casas.mitula.mx/casas/renta-haciendas-guadalajara,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,IxtlahuacÃ¡n de los membrillos,Renta,Hacienda,https://casas.mitula.mx/casas/renta-haciendas-ixtlahuacan-de-los-membrillos,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,JuanacatlÃ¡n,Renta,Hacienda,https://casas.mitula.mx/casas/renta-haciendas-juanacatlan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,San Pedro Tlaquepaque,Renta,Hacienda,https://casas.mitula.mx/casas/renta-haciendas-san-pedro-tlaquepaque,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Tlajomulco de ZuÃ±iga,Renta,Hacienda,https://casas.mitula.mx/casas/renta-haciendas-tlajomulco-de-zuniga,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,TonalÃ¡,Renta,Hacienda,https://casas.mitula.mx/casas/renta-haciendas-tonala,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapopan,Renta,Hacienda,https://casas.mitula.mx/casas/renta-haciendas-zapopan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapotlanejo,Renta,Hacienda,https://casas.mitula.mx/casas/renta-haciendas-zapotlanejo,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,El Salto,Venta,Hacienda,https://casas.mitula.mx/casas/venta-haciendas-el-salto,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Guadalajara,Venta,Hacienda,https://casas.mitula.mx/casas/venta-haciendas-guadalajara,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,IxtlahuacÃ¡n de los membrillos,Venta,Hacienda,https://casas.mitula.mx/casas/venta-haciendas-ixtlahuacan-de-los-membrillos,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,JuanacatlÃ¡n,Venta,Hacienda,https://casas.mitula.mx/casas/venta-haciendas-juanacatlan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,San Pedro Tlaquepaque,Venta,Hacienda,https://casas.mitula.mx/casas/venta-haciendas-san-pedro-tlaquepaque,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Tlajomulco de ZuÃ±iga,Venta,Hacienda,https://casas.mitula.mx/casas/venta-haciendas-tlajomulco-de-zuniga,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,TonalÃ¡,Venta,Hacienda,https://casas.mitula.mx/casas/venta-haciendas-tonala,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapopan,Venta,Hacienda,https://casas.mitula.mx/casas/venta-haciendas-zapopan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapotlanejo,Venta,Hacienda,https://casas.mitula.mx/casas/venta-haciendas-zapotlanejo,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,El Salto,Renta,Hotel,https://casas.mitula.mx/casas/renta-hoteles-el-salto,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Guadalajara,Renta,Hotel,https://casas.mitula.mx/casas/renta-hoteles-guadalajara,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,IxtlahuacÃ¡n de los membrillos,Renta,Hotel,https://casas.mitula.mx/casas/renta-hoteles-ixtlahuacan-de-los-membrillos,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,JuanacatlÃ¡n,Renta,Hotel,https://casas.mitula.mx/casas/renta-hoteles-juanacatlan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,San Pedro Tlaquepaque,Renta,Hotel,https://casas.mitula.mx/casas/renta-hoteles-san-pedro-tlaquepaque,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Tlajomulco de ZuÃ±iga,Renta,Hotel,https://casas.mitula.mx/casas/renta-hoteles-tlajomulco-de-zuniga,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,TonalÃ¡,Renta,Hotel,https://casas.mitula.mx/casas/renta-hoteles-tonala,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapopan,Renta,Hotel,https://casas.mitula.mx/casas/renta-hoteles-zapopan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapotlanejo,Renta,Hotel,https://casas.mitula.mx/casas/renta-hoteles-zapotlanejo,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,El Salto,Venta,Hotel,https://casas.mitula.mx/casas/venta-hoteles-el-salto,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Guadalajara,Venta,Hotel,https://casas.mitula.mx/casas/venta-hoteles-guadalajara,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,IxtlahuacÃ¡n de los membrillos,Venta,Hotel,https://casas.mitula.mx/casas/venta-hoteles-ixtlahuacan-de-los-membrillos,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,JuanacatlÃ¡n,Venta,Hotel,https://casas.mitula.mx/casas/venta-hoteles-juanacatlan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,San Pedro Tlaquepaque,Venta,Hotel,https://casas.mitula.mx/casas/venta-hoteles-san-pedro-tlaquepaque,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Tlajomulco de ZuÃ±iga,Venta,Hotel,https://casas.mitula.mx/casas/venta-hoteles-tlajomulco-de-zuniga,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,TonalÃ¡,Venta,Hotel,https://casas.mitula.mx/casas/venta-hoteles-tonala,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapopan,Venta,Hotel,https://casas.mitula.mx/casas/venta-hoteles-zapopan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapotlanejo,Venta,Hotel,https://casas.mitula.mx/casas/venta-hoteles-zapotlanejo,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,El Salto,Renta,Local Comercial,https://casas.mitula.mx/casas/renta-locales-comerciales-el-salto,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Guadalajara,Renta,Local Comercial,https://casas.mitula.mx/casas/renta-locales-comerciales-guadalajara,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,IxtlahuacÃ¡n de los membrillos,Renta,Local Comercial,https://casas.mitula.mx/casas/renta-locales-comerciales-ixtlahuacan-de-los-membrillos,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,JuanacatlÃ¡n,Renta,Local Comercial,https://casas.mitula.mx/casas/renta-locales-comerciales-juanacatlan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,San Pedro Tlaquepaque,Renta,Local Comercial,https://casas.mitula.mx/casas/renta-locales-comerciales-san-pedro-tlaquepaque,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Tlajomulco de ZuÃ±iga,Renta,Local Comercial,https://casas.mitula.mx/casas/renta-locales-comerciales-tlajomulco-de-zuniga,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,TonalÃ¡,Renta,Local Comercial,https://casas.mitula.mx/casas/renta-locales-comerciales-tonala,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapopan,Renta,Local Comercial,https://casas.mitula.mx/casas/renta-locales-comerciales-zapopan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapotlanejo,Renta,Local Comercial,https://casas.mitula.mx/casas/renta-locales-comerciales-zapotlanejo,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,El Salto,Venta,Local Comercial,https://casas.mitula.mx/casas/venta-locales-comerciales-el-salto,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Guadalajara,Venta,Local Comercial,https://casas.mitula.mx/casas/venta-locales-comerciales-guadalajara,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,IxtlahuacÃ¡n de los membrillos,Venta,Local Comercial,https://casas.mitula.mx/casas/venta-locales-comerciales-ixtlahuacan-de-los-membrillos,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,JuanacatlÃ¡n,Venta,Local Comercial,https://casas.mitula.mx/casas/venta-locales-comerciales-juanacatlan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,San Pedro Tlaquepaque,Venta,Local Comercial,https://casas.mitula.mx/casas/venta-locales-comerciales-san-pedro-tlaquepaque,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Tlajomulco de ZuÃ±iga,Venta,Local Comercial,https://casas.mitula.mx/casas/venta-locales-comerciales-tlajomulco-de-zuniga,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,TonalÃ¡,Venta,Local Comercial,https://casas.mitula.mx/casas/venta-locales-comerciales-tonala,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapopan,Venta,Local Comercial,https://casas.mitula.mx/casas/venta-locales-comerciales-zapopan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapotlanejo,Venta,Local Comercial,https://casas.mitula.mx/casas/venta-locales-comerciales-zapotlanejo,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,El Salto,Renta,Local en Centro Comercial,https://casas.mitula.mx/casas/renta-locales-en-centro-comercial-el-salto,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Guadalajara,Renta,Local en Centro Comercial,https://casas.mitula.mx/casas/renta-locales-en-centro-comercial-guadalajara,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,IxtlahuacÃ¡n de los membrillos,Renta,Local en Centro Comercial,https://casas.mitula.mx/casas/renta-locales-en-centro-comercial-ixtlahuacan-de-los-membrillos,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,JuanacatlÃ¡n,Renta,Local en Centro Comercial,https://casas.mitula.mx/casas/renta-locales-en-centro-comercial-juanacatlan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,San Pedro Tlaquepaque,Renta,Local en Centro Comercial,https://casas.mitula.mx/casas/renta-locales-en-centro-comercial-san-pedro-tlaquepaque,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Tlajomulco de ZuÃ±iga,Renta,Local en Centro Comercial,https://casas.mitula.mx/casas/renta-locales-en-centro-comercial-tlajomulco-de-zuniga,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,TonalÃ¡,Renta,Local en Centro Comercial,https://casas.mitula.mx/casas/renta-locales-en-centro-comercial-tonala,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapopan,Renta,Local en Centro Comercial,https://casas.mitula.mx/casas/renta-locales-en-centro-comercial-zapopan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapotlanejo,Renta,Local en Centro Comercial,https://casas.mitula.mx/casas/renta-locales-en-centro-comercial-zapotlanejo,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,El Salto,Venta,Local en Centro Comercial,https://casas.mitula.mx/casas/venta-locales-en-centro-comercial-el-salto,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Guadalajara,Venta,Local en Centro Comercial,https://casas.mitula.mx/casas/venta-locales-en-centro-comercial-guadalajara,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,IxtlahuacÃ¡n de los membrillos,Venta,Local en Centro Comercial,https://casas.mitula.mx/casas/venta-locales-en-centro-comercial-ixtlahuacan-de-los-membrillos,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,JuanacatlÃ¡n,Venta,Local en Centro Comercial,https://casas.mitula.mx/casas/venta-locales-en-centro-comercial-juanacatlan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,San Pedro Tlaquepaque,Venta,Local en Centro Comercial,https://casas.mitula.mx/casas/venta-locales-en-centro-comercial-san-pedro-tlaquepaque,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Tlajomulco de ZuÃ±iga,Venta,Local en Centro Comercial,https://casas.mitula.mx/casas/venta-locales-en-centro-comercial-tlajomulco-de-zuniga,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,TonalÃ¡,Venta,Local en Centro Comercial,https://casas.mitula.mx/casas/venta-locales-en-centro-comercial-tonala,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapopan,Venta,Local en Centro Comercial,https://casas.mitula.mx/casas/venta-locales-en-centro-comercial-zapopan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapotlanejo,Venta,Local en Centro Comercial,https://casas.mitula.mx/casas/venta-locales-en-centro-comercial-zapotlanejo,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,El Salto,Renta,Nave Industrial,https://casas.mitula.mx/casas/renta-naves-industriales-el-salto,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Guadalajara,Renta,Nave Industrial,https://casas.mitula.mx/casas/renta-naves-industriales-guadalajara,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,IxtlahuacÃ¡n de los membrillos,Renta,Nave Industrial,https://casas.mitula.mx/casas/renta-naves-industriales-ixtlahuacan-de-los-membrillos,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,JuanacatlÃ¡n,Renta,Nave Industrial,https://casas.mitula.mx/casas/renta-naves-industriales-juanacatlan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,San Pedro Tlaquepaque,Renta,Nave Industrial,https://casas.mitula.mx/casas/renta-naves-industriales-san-pedro-tlaquepaque,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Tlajomulco de ZuÃ±iga,Renta,Nave Industrial,https://casas.mitula.mx/casas/renta-naves-industriales-tlajomulco-de-zuniga,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,TonalÃ¡,Renta,Nave Industrial,https://casas.mitula.mx/casas/renta-naves-industriales-tonala,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapopan,Renta,Nave Industrial,https://casas.mitula.mx/casas/renta-naves-industriales-zapopan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapotlanejo,Renta,Nave Industrial,https://casas.mitula.mx/casas/renta-naves-industriales-zapotlanejo,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,El Salto,Venta,Nave Industrial,https://casas.mitula.mx/casas/venta-naves-industriales-el-salto,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Guadalajara,Venta,Nave Industrial,https://casas.mitula.mx/casas/venta-naves-industriales-guadalajara,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,IxtlahuacÃ¡n de los membrillos,Venta,Nave Industrial,https://casas.mitula.mx/casas/venta-naves-industriales-ixtlahuacan-de-los-membrillos,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,JuanacatlÃ¡n,Venta,Nave Industrial,https://casas.mitula.mx/casas/venta-naves-industriales-juanacatlan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,San Pedro Tlaquepaque,Venta,Nave Industrial,https://casas.mitula.mx/casas/venta-naves-industriales-san-pedro-tlaquepaque,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Tlajomulco de ZuÃ±iga,Venta,Nave Industrial,https://casas.mitula.mx/casas/venta-naves-industriales-tlajomulco-de-zuniga,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,TonalÃ¡,Venta,Nave Industrial,https://casas.mitula.mx/casas/venta-naves-industriales-tonala,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapopan,Venta,Nave Industrial,https://casas.mitula.mx/casas/venta-naves-industriales-zapopan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapotlanejo,Venta,Nave Industrial,https://casas.mitula.mx/casas/venta-naves-industriales-zapotlanejo,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,El Salto,Renta,Oficina,https://casas.mitula.mx/casas/renta-oficinas-el-salto,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Guadalajara,Renta,Oficina,https://casas.mitula.mx/casas/renta-oficinas-guadalajara,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,IxtlahuacÃ¡n de los membrillos,Renta,Oficina,https://casas.mitula.mx/casas/renta-oficinas-ixtlahuacan-de-los-membrillos,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,JuanacatlÃ¡n,Renta,Oficina,https://casas.mitula.mx/casas/renta-oficinas-juanacatlan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,San Pedro Tlaquepaque,Renta,Oficina,https://casas.mitula.mx/casas/renta-oficinas-san-pedro-tlaquepaque,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Tlajomulco de ZuÃ±iga,Renta,Oficina,https://casas.mitula.mx/casas/renta-oficinas-tlajomulco-de-zuniga,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,TonalÃ¡,Renta,Oficina,https://casas.mitula.mx/casas/renta-oficinas-tonala,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapopan,Renta,Oficina,https://casas.mitula.mx/casas/renta-oficinas-zapopan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapotlanejo,Renta,Oficina,https://casas.mitula.mx/casas/renta-oficinas-zapotlanejo,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,El Salto,Venta,Oficina,https://casas.mitula.mx/casas/venta-oficinas-el-salto,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Guadalajara,Venta,Oficina,https://casas.mitula.mx/casas/venta-oficinas-guadalajara,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,IxtlahuacÃ¡n de los membrillos,Venta,Oficina,https://casas.mitula.mx/casas/venta-oficinas-ixtlahuacan-de-los-membrillos,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,JuanacatlÃ¡n,Venta,Oficina,https://casas.mitula.mx/casas/venta-oficinas-juanacatlan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,San Pedro Tlaquepaque,Venta,Oficina,https://casas.mitula.mx/casas/venta-oficinas-san-pedro-tlaquepaque,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Tlajomulco de ZuÃ±iga,Venta,Oficina,https://casas.mitula.mx/casas/venta-oficinas-tlajomulco-de-zuniga,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,TonalÃ¡,Venta,Oficina,https://casas.mitula.mx/casas/venta-oficinas-tonala,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapopan,Venta,Oficina,https://casas.mitula.mx/casas/venta-oficinas-zapopan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapotlanejo,Venta,Oficina,https://casas.mitula.mx/casas/venta-oficinas-zapotlanejo,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,El Salto,Renta,Parcela,https://casas.mitula.mx/casas/renta-parcelas-el-salto,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Guadalajara,Renta,Parcela,https://casas.mitula.mx/casas/renta-parcelas-guadalajara,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,IxtlahuacÃ¡n de los membrillos,Renta,Parcela,https://casas.mitula.mx/casas/renta-parcelas-ixtlahuacan-de-los-membrillos,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,JuanacatlÃ¡n,Renta,Parcela,https://casas.mitula.mx/casas/renta-parcelas-juanacatlan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,San Pedro Tlaquepaque,Renta,Parcela,https://casas.mitula.mx/casas/renta-parcelas-san-pedro-tlaquepaque,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Tlajomulco de ZuÃ±iga,Renta,Parcela,https://casas.mitula.mx/casas/renta-parcelas-tlajomulco-de-zuniga,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,TonalÃ¡,Renta,Parcela,https://casas.mitula.mx/casas/renta-parcelas-tonala,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapopan,Renta,Parcela,https://casas.mitula.mx/casas/renta-parcelas-zapopan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapotlanejo,Renta,Parcela,https://casas.mitula.mx/casas/renta-parcelas-zapotlanejo,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,El Salto,Venta,Parcela,https://casas.mitula.mx/casas/venta-parcelas-el-salto,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Guadalajara,Venta,Parcela,https://casas.mitula.mx/casas/venta-parcelas-guadalajara,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,IxtlahuacÃ¡n de los membrillos,Venta,Parcela,https://casas.mitula.mx/casas/venta-parcelas-ixtlahuacan-de-los-membrillos,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,JuanacatlÃ¡n,Venta,Parcela,https://casas.mitula.mx/casas/venta-parcelas-juanacatlan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,San Pedro Tlaquepaque,Venta,Parcela,https://casas.mitula.mx/casas/venta-parcelas-san-pedro-tlaquepaque,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Tlajomulco de ZuÃ±iga,Venta,Parcela,https://casas.mitula.mx/casas/venta-parcelas-tlajomulco-de-zuniga,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,TonalÃ¡,Venta,Parcela,https://casas.mitula.mx/casas/venta-parcelas-tonala,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapopan,Venta,Parcela,https://casas.mitula.mx/casas/venta-parcelas-zapopan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapotlanejo,Venta,Parcela,https://casas.mitula.mx/casas/venta-parcelas-zapotlanejo,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,El Salto,Renta,Penthouse,https://casas.mitula.mx/casas/renta-penthouses-el-salto,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Guadalajara,Renta,Penthouse,https://casas.mitula.mx/casas/renta-penthouses-guadalajara,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,IxtlahuacÃ¡n de los membrillos,Renta,Penthouse,https://casas.mitula.mx/casas/renta-penthouses-ixtlahuacan-de-los-membrillos,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,JuanacatlÃ¡n,Renta,Penthouse,https://casas.mitula.mx/casas/renta-penthouses-juanacatlan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,San Pedro Tlaquepaque,Renta,Penthouse,https://casas.mitula.mx/casas/renta-penthouses-san-pedro-tlaquepaque,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Tlajomulco de ZuÃ±iga,Renta,Penthouse,https://casas.mitula.mx/casas/renta-penthouses-tlajomulco-de-zuniga,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,TonalÃ¡,Renta,Penthouse,https://casas.mitula.mx/casas/renta-penthouses-tonala,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapopan,Renta,Penthouse,https://casas.mitula.mx/casas/renta-penthouses-zapopan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapotlanejo,Renta,Penthouse,https://casas.mitula.mx/casas/renta-penthouses-zapotlanejo,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,El Salto,Venta,Penthouse,https://casas.mitula.mx/casas/venta-penthouses-el-salto,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Guadalajara,Venta,Penthouse,https://casas.mitula.mx/casas/venta-penthouses-guadalajara,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,IxtlahuacÃ¡n de los membrillos,Venta,Penthouse,https://casas.mitula.mx/casas/venta-penthouses-ixtlahuacan-de-los-membrillos,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,JuanacatlÃ¡n,Venta,Penthouse,https://casas.mitula.mx/casas/venta-penthouses-juanacatlan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,San Pedro Tlaquepaque,Venta,Penthouse,https://casas.mitula.mx/casas/venta-penthouses-san-pedro-tlaquepaque,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Tlajomulco de ZuÃ±iga,Venta,Penthouse,https://casas.mitula.mx/casas/venta-penthouses-tlajomulco-de-zuniga,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,TonalÃ¡,Venta,Penthouse,https://casas.mitula.mx/casas/venta-penthouses-tonala,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapopan,Venta,Penthouse,https://casas.mitula.mx/casas/venta-penthouses-zapopan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapotlanejo,Venta,Penthouse,https://casas.mitula.mx/casas/venta-penthouses-zapotlanejo,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,El Salto,Renta,Quinta,https://casas.mitula.mx/casas/renta-quintas-el-salto,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Guadalajara,Renta,Quinta,https://casas.mitula.mx/casas/renta-quintas-guadalajara,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,IxtlahuacÃ¡n de los membrillos,Renta,Quinta,https://casas.mitula.mx/casas/renta-quintas-ixtlahuacan-de-los-membrillos,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,JuanacatlÃ¡n,Renta,Quinta,https://casas.mitula.mx/casas/renta-quintas-juanacatlan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,San Pedro Tlaquepaque,Renta,Quinta,https://casas.mitula.mx/casas/renta-quintas-san-pedro-tlaquepaque,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Tlajomulco de ZuÃ±iga,Renta,Quinta,https://casas.mitula.mx/casas/renta-quintas-tlajomulco-de-zuniga,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,TonalÃ¡,Renta,Quinta,https://casas.mitula.mx/casas/renta-quintas-tonala,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapopan,Renta,Quinta,https://casas.mitula.mx/casas/renta-quintas-zapopan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapotlanejo,Renta,Quinta,https://casas.mitula.mx/casas/renta-quintas-zapotlanejo,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,El Salto,Venta,Quinta,https://casas.mitula.mx/casas/venta-quintas-el-salto,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Guadalajara,Venta,Quinta,https://casas.mitula.mx/casas/venta-quintas-guadalajara,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,IxtlahuacÃ¡n de los membrillos,Venta,Quinta,https://casas.mitula.mx/casas/venta-quintas-ixtlahuacan-de-los-membrillos,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,JuanacatlÃ¡n,Venta,Quinta,https://casas.mitula.mx/casas/venta-quintas-juanacatlan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,San Pedro Tlaquepaque,Venta,Quinta,https://casas.mitula.mx/casas/venta-quintas-san-pedro-tlaquepaque,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Tlajomulco de ZuÃ±iga,Venta,Quinta,https://casas.mitula.mx/casas/venta-quintas-tlajomulco-de-zuniga,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,TonalÃ¡,Venta,Quinta,https://casas.mitula.mx/casas/venta-quintas-tonala,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapopan,Venta,Quinta,https://casas.mitula.mx/casas/venta-quintas-zapopan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapotlanejo,Venta,Quinta,https://casas.mitula.mx/casas/venta-quintas-zapotlanejo,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,El Salto,Renta,Rancho,https://casas.mitula.mx/casas/renta-ranchos-el-salto,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Guadalajara,Renta,Rancho,https://casas.mitula.mx/casas/renta-ranchos-guadalajara,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,IxtlahuacÃ¡n de los membrillos,Renta,Rancho,https://casas.mitula.mx/casas/renta-ranchos-ixtlahuacan-de-los-membrillos,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,JuanacatlÃ¡n,Renta,Rancho,https://casas.mitula.mx/casas/renta-ranchos-juanacatlan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,San Pedro Tlaquepaque,Renta,Rancho,https://casas.mitula.mx/casas/renta-ranchos-san-pedro-tlaquepaque,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Tlajomulco de ZuÃ±iga,Renta,Rancho,https://casas.mitula.mx/casas/renta-ranchos-tlajomulco-de-zuniga,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,TonalÃ¡,Renta,Rancho,https://casas.mitula.mx/casas/renta-ranchos-tonala,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapopan,Renta,Rancho,https://casas.mitula.mx/casas/renta-ranchos-zapopan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapotlanejo,Renta,Rancho,https://casas.mitula.mx/casas/renta-ranchos-zapotlanejo,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,El Salto,Venta,Rancho,https://casas.mitula.mx/casas/venta-ranchos-el-salto,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Guadalajara,Venta,Rancho,https://casas.mitula.mx/casas/venta-ranchos-guadalajara,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,IxtlahuacÃ¡n de los membrillos,Venta,Rancho,https://casas.mitula.mx/casas/venta-ranchos-ixtlahuacan-de-los-membrillos,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,JuanacatlÃ¡n,Venta,Rancho,https://casas.mitula.mx/casas/venta-ranchos-juanacatlan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,San Pedro Tlaquepaque,Venta,Rancho,https://casas.mitula.mx/casas/venta-ranchos-san-pedro-tlaquepaque,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Tlajomulco de ZuÃ±iga,Venta,Rancho,https://casas.mitula.mx/casas/venta-ranchos-tlajomulco-de-zuniga,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,TonalÃ¡,Venta,Rancho,https://casas.mitula.mx/casas/venta-ranchos-tonala,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapopan,Venta,Rancho,https://casas.mitula.mx/casas/venta-ranchos-zapopan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapotlanejo,Venta,Rancho,https://casas.mitula.mx/casas/venta-ranchos-zapotlanejo,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,El Salto,Renta,Terreno,https://casas.mitula.mx/casas/renta-terrenos-el-salto,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Guadalajara,Renta,Terreno,https://casas.mitula.mx/casas/renta-terrenos-guadalajara,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,IxtlahuacÃ¡n de los membrillos,Renta,Terreno,https://casas.mitula.mx/casas/renta-terrenos-ixtlahuacan-de-los-membrillos,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,JuanacatlÃ¡n,Renta,Terreno,https://casas.mitula.mx/casas/renta-terrenos-juanacatlan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,San Pedro Tlaquepaque,Renta,Terreno,https://casas.mitula.mx/casas/renta-terrenos-san-pedro-tlaquepaque,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Tlajomulco de ZuÃ±iga,Renta,Terreno,https://casas.mitula.mx/casas/renta-terrenos-tlajomulco-de-zuniga,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,TonalÃ¡,Renta,Terreno,https://casas.mitula.mx/casas/renta-terrenos-tonala,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapopan,Renta,Terreno,https://casas.mitula.mx/casas/renta-terrenos-zapopan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapotlanejo,Renta,Terreno,https://casas.mitula.mx/casas/renta-terrenos-zapotlanejo,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,El Salto,Venta,Terreno,https://casas.mitula.mx/casas/venta-terrenos-el-salto,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Guadalajara,Venta,Terreno,https://casas.mitula.mx/casas/venta-terrenos-guadalajara,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,IxtlahuacÃ¡n de los membrillos,Venta,Terreno,https://casas.mitula.mx/casas/venta-terrenos-ixtlahuacan-de-los-membrillos,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,JuanacatlÃ¡n,Venta,Terreno,https://casas.mitula.mx/casas/venta-terrenos-juanacatlan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,San Pedro Tlaquepaque,Venta,Terreno,https://casas.mitula.mx/casas/venta-terrenos-san-pedro-tlaquepaque,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Tlajomulco de ZuÃ±iga,Venta,Terreno,https://casas.mitula.mx/casas/venta-terrenos-tlajomulco-de-zuniga,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,TonalÃ¡,Venta,Terreno,https://casas.mitula.mx/casas/venta-terrenos-tonala,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapopan,Venta,Terreno,https://casas.mitula.mx/casas/venta-terrenos-zapopan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapotlanejo,Venta,Terreno,https://casas.mitula.mx/casas/venta-terrenos-zapotlanejo,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,El Salto,Renta,Villa,https://casas.mitula.mx/casas/renta-villas-el-salto,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Guadalajara,Renta,Villa,https://casas.mitula.mx/casas/renta-villas-guadalajara,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,IxtlahuacÃ¡n de los membrillos,Renta,Villa,https://casas.mitula.mx/casas/renta-villas-ixtlahuacan-de-los-membrillos,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,JuanacatlÃ¡n,Renta,Villa,https://casas.mitula.mx/casas/renta-villas-juanacatlan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,San Pedro Tlaquepaque,Renta,Villa,https://casas.mitula.mx/casas/renta-villas-san-pedro-tlaquepaque,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Tlajomulco de ZuÃ±iga,Renta,Villa,https://casas.mitula.mx/casas/renta-villas-tlajomulco-de-zuniga,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,TonalÃ¡,Renta,Villa,https://casas.mitula.mx/casas/renta-villas-tonala,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapopan,Renta,Villa,https://casas.mitula.mx/casas/renta-villas-zapopan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapotlanejo,Renta,Villa,https://casas.mitula.mx/casas/renta-villas-zapotlanejo,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,El Salto,Venta,Villa,https://casas.mitula.mx/casas/venta-villas-el-salto,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Guadalajara,Venta,Villa,https://casas.mitula.mx/casas/venta-villas-guadalajara,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,IxtlahuacÃ¡n de los membrillos,Venta,Villa,https://casas.mitula.mx/casas/venta-villas-ixtlahuacan-de-los-membrillos,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,JuanacatlÃ¡n,Venta,Villa,https://casas.mitula.mx/casas/venta-villas-juanacatlan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,San Pedro Tlaquepaque,Venta,Villa,https://casas.mitula.mx/casas/venta-villas-san-pedro-tlaquepaque,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Tlajomulco de ZuÃ±iga,Venta,Villa,https://casas.mitula.mx/casas/venta-villas-tlajomulco-de-zuniga,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,TonalÃ¡,Venta,Villa,https://casas.mitula.mx/casas/venta-villas-tonala,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapopan,Venta,Villa,https://casas.mitula.mx/casas/venta-villas-zapopan,,,,,,,,,,,,,,,,,,,,,,,,,,,
-mitula,Zapotlanejo,Venta,Villa,https://casas.mitula.mx/casas/venta-villas-zapotlanejo,,,,,,,,,,,,,,,,,,,,,,,,,,,
+PaginaWeb,Ciudad,Operación,ProductoPaginaWeb,URL
+mitula,El Salto,Renta,Doctor office,https://casas.mitula.mx/casas/renta-doctor-office-el-salto
+mitula,Guadalajara,Renta,Doctor office,https://casas.mitula.mx/casas/renta-doctor-office-guadalajara
+mitula,Ixtlahuacán de los membrillos,Renta,Doctor office,https://casas.mitula.mx/casas/renta-doctor-office-ixtlahuacan-de-los-membrillos
+mitula,Juanacatlán,Renta,Doctor office,https://casas.mitula.mx/casas/renta-doctor-office-juanacatlan
+mitula,San Pedro Tlaquepaque,Renta,Doctor office,https://casas.mitula.mx/casas/renta-doctor-office-san-pedro-tlaquepaque
+mitula,Tlajomulco de Zuñiga,Renta,Doctor office,https://casas.mitula.mx/casas/renta-doctor-office-tlajomulco-de-zuniga
+mitula,Tonalá,Renta,Doctor office,https://casas.mitula.mx/casas/renta-doctor-office-tonala
+mitula,Zapopan,Renta,Doctor office,https://casas.mitula.mx/casas/renta-doctor-office-zapopan
+mitula,Zapotlanejo,Renta,Doctor office,https://casas.mitula.mx/casas/renta-doctor-office-zapotlanejo
+mitula,El Salto,Venta,Doctor office,https://casas.mitula.mx/casas/venta-doctor-office-el-salto
+mitula,Guadalajara,Venta,Doctor office,https://casas.mitula.mx/casas/venta-doctor-office-guadalajara
+mitula,Ixtlahuacán de los membrillos,Venta,Doctor office,https://casas.mitula.mx/casas/venta-doctor-office-ixtlahuacan-de-los-membrillos
+mitula,Juanacatlán,Venta,Doctor office,https://casas.mitula.mx/casas/venta-doctor-office-juanacatlan
+mitula,San Pedro Tlaquepaque,Venta,Doctor office,https://casas.mitula.mx/casas/venta-doctor-office-san-pedro-tlaquepaque
+mitula,Tlajomulco de Zuñiga,Venta,Doctor office,https://casas.mitula.mx/casas/venta-doctor-office-tlajomulco-de-zuniga
+mitula,Tonalá,Venta,Doctor office,https://casas.mitula.mx/casas/venta-doctor-office-tonala
+mitula,Zapopan,Venta,Doctor office,https://casas.mitula.mx/casas/venta-doctor-office-zapopan
+mitula,Zapotlanejo,Venta,Doctor office,https://casas.mitula.mx/casas/venta-doctor-office-zapotlanejo
+mitula,El Salto,Renta,Casa,https://casas.mitula.mx/casas/renta-casas-el-salto
+mitula,Guadalajara,Renta,Casa,https://casas.mitula.mx/casas/renta-casas-guadalajara
+mitula,Ixtlahuacán de los membrillos,Renta,Casa,https://casas.mitula.mx/casas/renta-casas-ixtlahuacan-de-los-membrillos
+mitula,Juanacatlán,Renta,Casa,https://casas.mitula.mx/casas/renta-casas-juanacatlan
+mitula,San Pedro Tlaquepaque,Renta,Casa,https://casas.mitula.mx/casas/renta-casas-san-pedro-tlaquepaque
+mitula,Tlajomulco de Zuñiga,Renta,Casa,https://casas.mitula.mx/casas/renta-casas-tlajomulco-de-zuniga
+mitula,Tonalá,Renta,Casa,https://casas.mitula.mx/casas/renta-casas-tonala
+mitula,Zapopan,Renta,Casa,https://casas.mitula.mx/casas/renta-casas-zapopan
+mitula,Zapotlanejo,Renta,Casa,https://casas.mitula.mx/casas/renta-casas-zapotlanejo
+mitula,El Salto,Venta,Casa,https://casas.mitula.mx/casas/venta-casas-el-salto
+mitula,Guadalajara,Venta,Casa,https://casas.mitula.mx/casas/venta-casas-guadalajara
+mitula,Ixtlahuacán de los membrillos,Venta,Casa,https://casas.mitula.mx/casas/venta-casas-ixtlahuacan-de-los-membrillos
+mitula,Juanacatlán,Venta,Casa,https://casas.mitula.mx/casas/venta-casas-juanacatlan
+mitula,San Pedro Tlaquepaque,Venta,Casa,https://casas.mitula.mx/casas/venta-casas-san-pedro-tlaquepaque
+mitula,Tlajomulco de Zuñiga,Venta,Casa,https://casas.mitula.mx/casas/venta-casas-tlajomulco-de-zuniga
+mitula,Tonalá,Venta,Casa,https://casas.mitula.mx/casas/venta-casas-tonala
+mitula,Zapopan,Venta,Casa,https://casas.mitula.mx/casas/venta-casas-zapopan
+mitula,Zapotlanejo,Venta,Casa,https://casas.mitula.mx/casas/venta-casas-zapotlanejo
+mitula,El Salto,Renta,Ático,https://casas.mitula.mx/casas/renta-aticos-el-salto
+mitula,Guadalajara,Renta,Ático,https://casas.mitula.mx/casas/renta-aticos-guadalajara
+mitula,Ixtlahuacán de los membrillos,Renta,Ático,https://casas.mitula.mx/casas/renta-aticos-ixtlahuacan-de-los-membrillos
+mitula,Juanacatlán,Renta,Ático,https://casas.mitula.mx/casas/renta-aticos-juanacatlan
+mitula,San Pedro Tlaquepaque,Renta,Ático,https://casas.mitula.mx/casas/renta-aticos-san-pedro-tlaquepaque
+mitula,Tlajomulco de Zuñiga,Renta,Ático,https://casas.mitula.mx/casas/renta-aticos-tlajomulco-de-zuniga
+mitula,Tonalá,Renta,Ático,https://casas.mitula.mx/casas/renta-aticos-tonala
+mitula,Zapopan,Renta,Ático,https://casas.mitula.mx/casas/renta-aticos-zapopan
+mitula,Zapotlanejo,Renta,Ático,https://casas.mitula.mx/casas/renta-aticos-zapotlanejo
+mitula,El Salto,Venta,Ático,https://casas.mitula.mx/casas/venta-aticos-el-salto
+mitula,Guadalajara,Venta,Ático,https://casas.mitula.mx/casas/venta-aticos-guadalajara
+mitula,Ixtlahuacán de los membrillos,Venta,Ático,https://casas.mitula.mx/casas/venta-aticos-ixtlahuacan-de-los-membrillos
+mitula,Juanacatlán,Venta,Ático,https://casas.mitula.mx/casas/venta-aticos-juanacatlan
+mitula,San Pedro Tlaquepaque,Venta,Ático,https://casas.mitula.mx/casas/venta-aticos-san-pedro-tlaquepaque
+mitula,Tlajomulco de Zuñiga,Venta,Ático,https://casas.mitula.mx/casas/venta-aticos-tlajomulco-de-zuniga
+mitula,Tonalá,Venta,Ático,https://casas.mitula.mx/casas/venta-aticos-tonala
+mitula,Zapopan,Venta,Ático,https://casas.mitula.mx/casas/venta-aticos-zapopan
+mitula,Zapotlanejo,Venta,Ático,https://casas.mitula.mx/casas/venta-aticos-zapotlanejo
+mitula,El Salto,Renta,Bodega,https://casas.mitula.mx/casas/renta-bodegas-el-salto
+mitula,Guadalajara,Renta,Bodega,https://casas.mitula.mx/casas/renta-bodegas-guadalajara
+mitula,Ixtlahuacán de los membrillos,Renta,Bodega,https://casas.mitula.mx/casas/renta-bodegas-ixtlahuacan-de-los-membrillos
+mitula,Juanacatlán,Renta,Bodega,https://casas.mitula.mx/casas/renta-bodegas-juanacatlan
+mitula,San Pedro Tlaquepaque,Renta,Bodega,https://casas.mitula.mx/casas/renta-bodegas-san-pedro-tlaquepaque
+mitula,Tlajomulco de Zuñiga,Renta,Bodega,https://casas.mitula.mx/casas/renta-bodegas-tlajomulco-de-zuniga
+mitula,Tonalá,Renta,Bodega,https://casas.mitula.mx/casas/renta-bodegas-tonala
+mitula,Zapopan,Renta,Bodega,https://casas.mitula.mx/casas/renta-bodegas-zapopan
+mitula,Zapotlanejo,Renta,Bodega,https://casas.mitula.mx/casas/renta-bodegas-zapotlanejo
+mitula,El Salto,Venta,Bodega,https://casas.mitula.mx/casas/venta-bodegas-el-salto
+mitula,Guadalajara,Venta,Bodega,https://casas.mitula.mx/casas/venta-bodegas-guadalajara
+mitula,Ixtlahuacán de los membrillos,Venta,Bodega,https://casas.mitula.mx/casas/venta-bodegas-ixtlahuacan-de-los-membrillos
+mitula,Juanacatlán,Venta,Bodega,https://casas.mitula.mx/casas/venta-bodegas-juanacatlan
+mitula,San Pedro Tlaquepaque,Venta,Bodega,https://casas.mitula.mx/casas/venta-bodegas-san-pedro-tlaquepaque
+mitula,Tlajomulco de Zuñiga,Venta,Bodega,https://casas.mitula.mx/casas/venta-bodegas-tlajomulco-de-zuniga
+mitula,Tonalá,Venta,Bodega,https://casas.mitula.mx/casas/venta-bodegas-tonala
+mitula,Zapopan,Venta,Bodega,https://casas.mitula.mx/casas/venta-bodegas-zapopan
+mitula,Zapotlanejo,Venta,Bodega,https://casas.mitula.mx/casas/venta-bodegas-zapotlanejo
+mitula,El Salto,Renta,Bungalow,https://casas.mitula.mx/casas/renta-bungalows-el-salto
+mitula,Guadalajara,Renta,Bungalow,https://casas.mitula.mx/casas/renta-bungalows-guadalajara
+mitula,Ixtlahuacán de los membrillos,Renta,Bungalow,https://casas.mitula.mx/casas/renta-bungalows-ixtlahuacan-de-los-membrillos
+mitula,Juanacatlán,Renta,Bungalow,https://casas.mitula.mx/casas/renta-bungalows-juanacatlan
+mitula,San Pedro Tlaquepaque,Renta,Bungalow,https://casas.mitula.mx/casas/renta-bungalows-san-pedro-tlaquepaque
+mitula,Tlajomulco de Zuñiga,Renta,Bungalow,https://casas.mitula.mx/casas/renta-bungalows-tlajomulco-de-zuniga
+mitula,Tonalá,Renta,Bungalow,https://casas.mitula.mx/casas/renta-bungalows-tonala
+mitula,Zapopan,Renta,Bungalow,https://casas.mitula.mx/casas/renta-bungalows-zapopan
+mitula,Zapotlanejo,Renta,Bungalow,https://casas.mitula.mx/casas/renta-bungalows-zapotlanejo
+mitula,El Salto,Venta,Bungalow,https://casas.mitula.mx/casas/venta-bungalows-el-salto
+mitula,Guadalajara,Venta,Bungalow,https://casas.mitula.mx/casas/venta-bungalows-guadalajara
+mitula,Ixtlahuacán de los membrillos,Venta,Bungalow,https://casas.mitula.mx/casas/venta-bungalows-ixtlahuacan-de-los-membrillos
+mitula,Juanacatlán,Venta,Bungalow,https://casas.mitula.mx/casas/venta-bungalows-juanacatlan
+mitula,San Pedro Tlaquepaque,Venta,Bungalow,https://casas.mitula.mx/casas/venta-bungalows-san-pedro-tlaquepaque
+mitula,Tlajomulco de Zuñiga,Venta,Bungalow,https://casas.mitula.mx/casas/venta-bungalows-tlajomulco-de-zuniga
+mitula,Tonalá,Venta,Bungalow,https://casas.mitula.mx/casas/venta-bungalows-tonala
+mitula,Zapopan,Venta,Bungalow,https://casas.mitula.mx/casas/venta-bungalows-zapopan
+mitula,Zapotlanejo,Venta,Bungalow,https://casas.mitula.mx/casas/venta-bungalows-zapotlanejo
+mitula,El Salto,Renta,Casa en Condominio,https://casas.mitula.mx/casas/renta-casas-en-condominio-el-salto
+mitula,Guadalajara,Renta,Casa en Condominio,https://casas.mitula.mx/casas/renta-casas-en-condominio-guadalajara
+mitula,Ixtlahuacán de los membrillos,Renta,Casa en Condominio,https://casas.mitula.mx/casas/renta-casas-en-condominio-ixtlahuacan-de-los-membrillos
+mitula,Juanacatlán,Renta,Casa en Condominio,https://casas.mitula.mx/casas/renta-casas-en-condominio-juanacatlan
+mitula,San Pedro Tlaquepaque,Renta,Casa en Condominio,https://casas.mitula.mx/casas/renta-casas-en-condominio-san-pedro-tlaquepaque
+mitula,Tlajomulco de Zuñiga,Renta,Casa en Condominio,https://casas.mitula.mx/casas/renta-casas-en-condominio-tlajomulco-de-zuniga
+mitula,Tonalá,Renta,Casa en Condominio,https://casas.mitula.mx/casas/renta-casas-en-condominio-tonala
+mitula,Zapopan,Renta,Casa en Condominio,https://casas.mitula.mx/casas/renta-casas-en-condominio-zapopan
+mitula,Zapotlanejo,Renta,Casa en Condominio,https://casas.mitula.mx/casas/renta-casas-en-condominio-zapotlanejo
+mitula,El Salto,Venta,Casa en Condominio,https://casas.mitula.mx/casas/venta-casas-en-condominio-el-salto
+mitula,Guadalajara,Venta,Casa en Condominio,https://casas.mitula.mx/casas/venta-casas-en-condominio-guadalajara
+mitula,Ixtlahuacán de los membrillos,Venta,Casa en Condominio,https://casas.mitula.mx/casas/venta-casas-en-condominio-ixtlahuacan-de-los-membrillos
+mitula,Juanacatlán,Venta,Casa en Condominio,https://casas.mitula.mx/casas/venta-casas-en-condominio-juanacatlan
+mitula,San Pedro Tlaquepaque,Venta,Casa en Condominio,https://casas.mitula.mx/casas/venta-casas-en-condominio-san-pedro-tlaquepaque
+mitula,Tlajomulco de Zuñiga,Venta,Casa en Condominio,https://casas.mitula.mx/casas/venta-casas-en-condominio-tlajomulco-de-zuniga
+mitula,Tonalá,Venta,Casa en Condominio,https://casas.mitula.mx/casas/venta-casas-en-condominio-tonala
+mitula,Zapopan,Venta,Casa en Condominio,https://casas.mitula.mx/casas/venta-casas-en-condominio-zapopan
+mitula,Zapotlanejo,Venta,Casa en Condominio,https://casas.mitula.mx/casas/venta-casas-en-condominio-zapotlanejo
+mitula,El Salto,Renta,Casa en Fraccionamiento,https://casas.mitula.mx/casas/renta-casas-en-fraccionamiento-el-salto
+mitula,Guadalajara,Renta,Casa en Fraccionamiento,https://casas.mitula.mx/casas/renta-casas-en-fraccionamiento-guadalajara
+mitula,Ixtlahuacán de los membrillos,Renta,Casa en Fraccionamiento,https://casas.mitula.mx/casas/renta-casas-en-fraccionamiento-ixtlahuacan-de-los-membrillos
+mitula,Juanacatlán,Renta,Casa en Fraccionamiento,https://casas.mitula.mx/casas/renta-casas-en-fraccionamiento-juanacatlan
+mitula,San Pedro Tlaquepaque,Renta,Casa en Fraccionamiento,https://casas.mitula.mx/casas/renta-casas-en-fraccionamiento-san-pedro-tlaquepaque
+mitula,Tlajomulco de Zuñiga,Renta,Casa en Fraccionamiento,https://casas.mitula.mx/casas/renta-casas-en-fraccionamiento-tlajomulco-de-zuniga
+mitula,Tonalá,Renta,Casa en Fraccionamiento,https://casas.mitula.mx/casas/renta-casas-en-fraccionamiento-tonala
+mitula,Zapopan,Renta,Casa en Fraccionamiento,https://casas.mitula.mx/casas/renta-casas-en-fraccionamiento-zapopan
+mitula,Zapotlanejo,Renta,Casa en Fraccionamiento,https://casas.mitula.mx/casas/renta-casas-en-fraccionamiento-zapotlanejo
+mitula,El Salto,Venta,Casa en Fraccionamiento,https://casas.mitula.mx/casas/venta-casas-en-fraccionamiento-el-salto
+mitula,Guadalajara,Venta,Casa en Fraccionamiento,https://casas.mitula.mx/casas/venta-casas-en-fraccionamiento-guadalajara
+mitula,Ixtlahuacán de los membrillos,Venta,Casa en Fraccionamiento,https://casas.mitula.mx/casas/venta-casas-en-fraccionamiento-ixtlahuacan-de-los-membrillos
+mitula,Juanacatlán,Venta,Casa en Fraccionamiento,https://casas.mitula.mx/casas/venta-casas-en-fraccionamiento-juanacatlan
+mitula,San Pedro Tlaquepaque,Venta,Casa en Fraccionamiento,https://casas.mitula.mx/casas/venta-casas-en-fraccionamiento-san-pedro-tlaquepaque
+mitula,Tlajomulco de Zuñiga,Venta,Casa en Fraccionamiento,https://casas.mitula.mx/casas/venta-casas-en-fraccionamiento-tlajomulco-de-zuniga
+mitula,Tonalá,Venta,Casa en Fraccionamiento,https://casas.mitula.mx/casas/venta-casas-en-fraccionamiento-tonala
+mitula,Zapopan,Venta,Casa en Fraccionamiento,https://casas.mitula.mx/casas/venta-casas-en-fraccionamiento-zapopan
+mitula,Zapotlanejo,Venta,Casa en Fraccionamiento,https://casas.mitula.mx/casas/venta-casas-en-fraccionamiento-zapotlanejo
+mitula,El Salto,Renta,Condominio Horizontal,https://casas.mitula.mx/casas/renta-condominio-horizontal-el-salto
+mitula,Guadalajara,Renta,Condominio Horizontal,https://casas.mitula.mx/casas/renta-condominio-horizontal-guadalajara
+mitula,Ixtlahuacán de los membrillos,Renta,Condominio Horizontal,https://casas.mitula.mx/casas/renta-condominio-horizontal-ixtlahuacan-de-los-membrillos
+mitula,Juanacatlán,Renta,Condominio Horizontal,https://casas.mitula.mx/casas/renta-condominio-horizontal-juanacatlan
+mitula,San Pedro Tlaquepaque,Renta,Condominio Horizontal,https://casas.mitula.mx/casas/renta-condominio-horizontal-san-pedro-tlaquepaque
+mitula,Tlajomulco de Zuñiga,Renta,Condominio Horizontal,https://casas.mitula.mx/casas/renta-condominio-horizontal-tlajomulco-de-zuniga
+mitula,Tonalá,Renta,Condominio Horizontal,https://casas.mitula.mx/casas/renta-condominio-horizontal-tonala
+mitula,Zapopan,Renta,Condominio Horizontal,https://casas.mitula.mx/casas/renta-condominio-horizontal-zapopan
+mitula,Zapotlanejo,Renta,Condominio Horizontal,https://casas.mitula.mx/casas/renta-condominio-horizontal-zapotlanejo
+mitula,El Salto,Venta,Condominio Horizontal,https://casas.mitula.mx/casas/venta-condominio-horizontal-el-salto
+mitula,Guadalajara,Venta,Condominio Horizontal,https://casas.mitula.mx/casas/venta-condominio-horizontal-guadalajara
+mitula,Ixtlahuacán de los membrillos,Venta,Condominio Horizontal,https://casas.mitula.mx/casas/venta-condominio-horizontal-ixtlahuacan-de-los-membrillos
+mitula,Juanacatlán,Venta,Condominio Horizontal,https://casas.mitula.mx/casas/venta-condominio-horizontal-juanacatlan
+mitula,San Pedro Tlaquepaque,Venta,Condominio Horizontal,https://casas.mitula.mx/casas/venta-condominio-horizontal-san-pedro-tlaquepaque
+mitula,Tlajomulco de Zuñiga,Venta,Condominio Horizontal,https://casas.mitula.mx/casas/venta-condominio-horizontal-tlajomulco-de-zuniga
+mitula,Tonalá,Venta,Condominio Horizontal,https://casas.mitula.mx/casas/venta-condominio-horizontal-tonala
+mitula,Zapopan,Venta,Condominio Horizontal,https://casas.mitula.mx/casas/venta-condominio-horizontal-zapopan
+mitula,Zapotlanejo,Venta,Condominio Horizontal,https://casas.mitula.mx/casas/venta-condominio-horizontal-zapotlanejo
+mitula,El Salto,Renta,Cuarto,https://casas.mitula.mx/casas/renta-cuartos-el-salto
+mitula,Guadalajara,Renta,Cuarto,https://casas.mitula.mx/casas/renta-cuartos-guadalajara
+mitula,Ixtlahuacán de los membrillos,Renta,Cuarto,https://casas.mitula.mx/casas/renta-cuartos-ixtlahuacan-de-los-membrillos
+mitula,Juanacatlán,Renta,Cuarto,https://casas.mitula.mx/casas/renta-cuartos-juanacatlan
+mitula,San Pedro Tlaquepaque,Renta,Cuarto,https://casas.mitula.mx/casas/renta-cuartos-san-pedro-tlaquepaque
+mitula,Tlajomulco de Zuñiga,Renta,Cuarto,https://casas.mitula.mx/casas/renta-cuartos-tlajomulco-de-zuniga
+mitula,Tonalá,Renta,Cuarto,https://casas.mitula.mx/casas/renta-cuartos-tonala
+mitula,Zapopan,Renta,Cuarto,https://casas.mitula.mx/casas/renta-cuartos-zapopan
+mitula,Zapotlanejo,Renta,Cuarto,https://casas.mitula.mx/casas/renta-cuartos-zapotlanejo
+mitula,El Salto,Venta,Cuarto,https://casas.mitula.mx/casas/venta-cuartos-el-salto
+mitula,Guadalajara,Venta,Cuarto,https://casas.mitula.mx/casas/venta-cuartos-guadalajara
+mitula,Ixtlahuacán de los membrillos,Venta,Cuarto,https://casas.mitula.mx/casas/venta-cuartos-ixtlahuacan-de-los-membrillos
+mitula,Juanacatlán,Venta,Cuarto,https://casas.mitula.mx/casas/venta-cuartos-juanacatlan
+mitula,San Pedro Tlaquepaque,Venta,Cuarto,https://casas.mitula.mx/casas/venta-cuartos-san-pedro-tlaquepaque
+mitula,Tlajomulco de Zuñiga,Venta,Cuarto,https://casas.mitula.mx/casas/venta-cuartos-tlajomulco-de-zuniga
+mitula,Tonalá,Venta,Cuarto,https://casas.mitula.mx/casas/venta-cuartos-tonala
+mitula,Zapopan,Venta,Cuarto,https://casas.mitula.mx/casas/venta-cuartos-zapopan
+mitula,Zapotlanejo,Venta,Cuarto,https://casas.mitula.mx/casas/venta-cuartos-zapotlanejo
+mitula,El Salto,Renta,Dúplex,https://casas.mitula.mx/casas/renta-duplex-el-salto
+mitula,Guadalajara,Renta,Dúplex,https://casas.mitula.mx/casas/renta-duplex-guadalajara
+mitula,Ixtlahuacán de los membrillos,Renta,Dúplex,https://casas.mitula.mx/casas/renta-duplex-ixtlahuacan-de-los-membrillos
+mitula,Juanacatlán,Renta,Dúplex,https://casas.mitula.mx/casas/renta-duplex-juanacatlan
+mitula,San Pedro Tlaquepaque,Renta,Dúplex,https://casas.mitula.mx/casas/renta-duplex-san-pedro-tlaquepaque
+mitula,Tlajomulco de Zuñiga,Renta,Dúplex,https://casas.mitula.mx/casas/renta-duplex-tlajomulco-de-zuniga
+mitula,Tonalá,Renta,Dúplex,https://casas.mitula.mx/casas/renta-duplex-tonala
+mitula,Zapopan,Renta,Dúplex,https://casas.mitula.mx/casas/renta-duplex-zapopan
+mitula,Zapotlanejo,Renta,Dúplex,https://casas.mitula.mx/casas/renta-duplex-zapotlanejo
+mitula,El Salto,Venta,Dúplex,https://casas.mitula.mx/casas/venta-duplex-el-salto
+mitula,Guadalajara,Venta,Dúplex,https://casas.mitula.mx/casas/venta-duplex-guadalajara
+mitula,Ixtlahuacán de los membrillos,Venta,Dúplex,https://casas.mitula.mx/casas/venta-duplex-ixtlahuacan-de-los-membrillos
+mitula,Juanacatlán,Venta,Dúplex,https://casas.mitula.mx/casas/venta-duplex-juanacatlan
+mitula,San Pedro Tlaquepaque,Venta,Dúplex,https://casas.mitula.mx/casas/venta-duplex-san-pedro-tlaquepaque
+mitula,Tlajomulco de Zuñiga,Venta,Dúplex,https://casas.mitula.mx/casas/venta-duplex-tlajomulco-de-zuniga
+mitula,Tonalá,Venta,Dúplex,https://casas.mitula.mx/casas/venta-duplex-tonala
+mitula,Zapopan,Venta,Dúplex,https://casas.mitula.mx/casas/venta-duplex-zapopan
+mitula,Zapotlanejo,Venta,Dúplex,https://casas.mitula.mx/casas/venta-duplex-zapotlanejo
+mitula,El Salto,Renta,Departamento,https://casas.mitula.mx/casas/renta-departamentos-el-salto
+mitula,Guadalajara,Renta,Departamento,https://casas.mitula.mx/casas/renta-departamentos-guadalajara
+mitula,Ixtlahuacán de los membrillos,Renta,Departamento,https://casas.mitula.mx/casas/renta-departamentos-ixtlahuacan-de-los-membrillos
+mitula,Juanacatlán,Renta,Departamento,https://casas.mitula.mx/casas/renta-departamentos-juanacatlan
+mitula,San Pedro Tlaquepaque,Renta,Departamento,https://casas.mitula.mx/casas/renta-departamentos-san-pedro-tlaquepaque
+mitula,Tlajomulco de Zuñiga,Renta,Departamento,https://casas.mitula.mx/casas/renta-departamentos-tlajomulco-de-zuniga
+mitula,Tonalá,Renta,Departamento,https://casas.mitula.mx/casas/renta-departamentos-tonala
+mitula,Zapopan,Renta,Departamento,https://casas.mitula.mx/casas/renta-departamentos-zapopan
+mitula,Zapotlanejo,Renta,Departamento,https://casas.mitula.mx/casas/renta-departamentos-zapotlanejo
+mitula,El Salto,Venta,Departamento,https://casas.mitula.mx/casas/venta-departamentos-el-salto
+mitula,Guadalajara,Venta,Departamento,https://casas.mitula.mx/casas/venta-departamentos-guadalajara
+mitula,Ixtlahuacán de los membrillos,Venta,Departamento,https://casas.mitula.mx/casas/venta-departamentos-ixtlahuacan-de-los-membrillos
+mitula,Juanacatlán,Venta,Departamento,https://casas.mitula.mx/casas/venta-departamentos-juanacatlan
+mitula,San Pedro Tlaquepaque,Venta,Departamento,https://casas.mitula.mx/casas/venta-departamentos-san-pedro-tlaquepaque
+mitula,Tlajomulco de Zuñiga,Venta,Departamento,https://casas.mitula.mx/casas/venta-departamentos-tlajomulco-de-zuniga
+mitula,Tonalá,Venta,Departamento,https://casas.mitula.mx/casas/venta-departamentos-tonala
+mitula,Zapopan,Venta,Departamento,https://casas.mitula.mx/casas/venta-departamentos-zapopan
+mitula,Zapotlanejo,Venta,Departamento,https://casas.mitula.mx/casas/venta-departamentos-zapotlanejo
+mitula,El Salto,Renta,Desván,https://casas.mitula.mx/casas/renta-desvanes-el-salto
+mitula,Guadalajara,Renta,Desván,https://casas.mitula.mx/casas/renta-desvanes-guadalajara
+mitula,Ixtlahuacán de los membrillos,Renta,Desván,https://casas.mitula.mx/casas/renta-desvanes-ixtlahuacan-de-los-membrillos
+mitula,Juanacatlán,Renta,Desván,https://casas.mitula.mx/casas/renta-desvanes-juanacatlan
+mitula,San Pedro Tlaquepaque,Renta,Desván,https://casas.mitula.mx/casas/renta-desvanes-san-pedro-tlaquepaque
+mitula,Tlajomulco de Zuñiga,Renta,Desván,https://casas.mitula.mx/casas/renta-desvanes-tlajomulco-de-zuniga
+mitula,Tonalá,Renta,Desván,https://casas.mitula.mx/casas/renta-desvanes-tonala
+mitula,Zapopan,Renta,Desván,https://casas.mitula.mx/casas/renta-desvanes-zapopan
+mitula,Zapotlanejo,Renta,Desván,https://casas.mitula.mx/casas/renta-desvanes-zapotlanejo
+mitula,El Salto,Venta,Desván,https://casas.mitula.mx/casas/venta-desvanes-el-salto
+mitula,Guadalajara,Venta,Desván,https://casas.mitula.mx/casas/venta-desvanes-guadalajara
+mitula,Ixtlahuacán de los membrillos,Venta,Desván,https://casas.mitula.mx/casas/venta-desvanes-ixtlahuacan-de-los-membrillos
+mitula,Juanacatlán,Venta,Desván,https://casas.mitula.mx/casas/venta-desvanes-juanacatlan
+mitula,San Pedro Tlaquepaque,Venta,Desván,https://casas.mitula.mx/casas/venta-desvanes-san-pedro-tlaquepaque
+mitula,Tlajomulco de Zuñiga,Venta,Desván,https://casas.mitula.mx/casas/venta-desvanes-tlajomulco-de-zuniga
+mitula,Tonalá,Venta,Desván,https://casas.mitula.mx/casas/venta-desvanes-tonala
+mitula,Zapopan,Venta,Desván,https://casas.mitula.mx/casas/venta-desvanes-zapopan
+mitula,Zapotlanejo,Venta,Desván,https://casas.mitula.mx/casas/venta-desvanes-zapotlanejo
+mitula,El Salto,Renta,Edificio,https://casas.mitula.mx/casas/renta-edificios-el-salto
+mitula,Guadalajara,Renta,Edificio,https://casas.mitula.mx/casas/renta-edificios-guadalajara
+mitula,Ixtlahuacán de los membrillos,Renta,Edificio,https://casas.mitula.mx/casas/renta-edificios-ixtlahuacan-de-los-membrillos
+mitula,Juanacatlán,Renta,Edificio,https://casas.mitula.mx/casas/renta-edificios-juanacatlan
+mitula,San Pedro Tlaquepaque,Renta,Edificio,https://casas.mitula.mx/casas/renta-edificios-san-pedro-tlaquepaque
+mitula,Tlajomulco de Zuñiga,Renta,Edificio,https://casas.mitula.mx/casas/renta-edificios-tlajomulco-de-zuniga
+mitula,Tonalá,Renta,Edificio,https://casas.mitula.mx/casas/renta-edificios-tonala
+mitula,Zapopan,Renta,Edificio,https://casas.mitula.mx/casas/renta-edificios-zapopan
+mitula,Zapotlanejo,Renta,Edificio,https://casas.mitula.mx/casas/renta-edificios-zapotlanejo
+mitula,El Salto,Venta,Edificio,https://casas.mitula.mx/casas/venta-edificios-el-salto
+mitula,Guadalajara,Venta,Edificio,https://casas.mitula.mx/casas/venta-edificios-guadalajara
+mitula,Ixtlahuacán de los membrillos,Venta,Edificio,https://casas.mitula.mx/casas/venta-edificios-ixtlahuacan-de-los-membrillos
+mitula,Juanacatlán,Venta,Edificio,https://casas.mitula.mx/casas/venta-edificios-juanacatlan
+mitula,San Pedro Tlaquepaque,Venta,Edificio,https://casas.mitula.mx/casas/venta-edificios-san-pedro-tlaquepaque
+mitula,Tlajomulco de Zuñiga,Venta,Edificio,https://casas.mitula.mx/casas/venta-edificios-tlajomulco-de-zuniga
+mitula,Tonalá,Venta,Edificio,https://casas.mitula.mx/casas/venta-edificios-tonala
+mitula,Zapopan,Venta,Edificio,https://casas.mitula.mx/casas/venta-edificios-zapopan
+mitula,Zapotlanejo,Venta,Edificio,https://casas.mitula.mx/casas/venta-edificios-zapotlanejo
+mitula,El Salto,Renta,Estudio,https://casas.mitula.mx/casas/renta-estudios-el-salto
+mitula,Guadalajara,Renta,Estudio,https://casas.mitula.mx/casas/renta-estudios-guadalajara
+mitula,Ixtlahuacán de los membrillos,Renta,Estudio,https://casas.mitula.mx/casas/renta-estudios-ixtlahuacan-de-los-membrillos
+mitula,Juanacatlán,Renta,Estudio,https://casas.mitula.mx/casas/renta-estudios-juanacatlan
+mitula,San Pedro Tlaquepaque,Renta,Estudio,https://casas.mitula.mx/casas/renta-estudios-san-pedro-tlaquepaque
+mitula,Tlajomulco de Zuñiga,Renta,Estudio,https://casas.mitula.mx/casas/renta-estudios-tlajomulco-de-zuniga
+mitula,Tonalá,Renta,Estudio,https://casas.mitula.mx/casas/renta-estudios-tonala
+mitula,Zapopan,Renta,Estudio,https://casas.mitula.mx/casas/renta-estudios-zapopan
+mitula,Zapotlanejo,Renta,Estudio,https://casas.mitula.mx/casas/renta-estudios-zapotlanejo
+mitula,El Salto,Venta,Estudio,https://casas.mitula.mx/casas/venta-estudios-el-salto
+mitula,Guadalajara,Venta,Estudio,https://casas.mitula.mx/casas/venta-estudios-guadalajara
+mitula,Ixtlahuacán de los membrillos,Venta,Estudio,https://casas.mitula.mx/casas/venta-estudios-ixtlahuacan-de-los-membrillos
+mitula,Juanacatlán,Venta,Estudio,https://casas.mitula.mx/casas/venta-estudios-juanacatlan
+mitula,San Pedro Tlaquepaque,Venta,Estudio,https://casas.mitula.mx/casas/venta-estudios-san-pedro-tlaquepaque
+mitula,Tlajomulco de Zuñiga,Venta,Estudio,https://casas.mitula.mx/casas/venta-estudios-tlajomulco-de-zuniga
+mitula,Tonalá,Venta,Estudio,https://casas.mitula.mx/casas/venta-estudios-tonala
+mitula,Zapopan,Venta,Estudio,https://casas.mitula.mx/casas/venta-estudios-zapopan
+mitula,Zapotlanejo,Venta,Estudio,https://casas.mitula.mx/casas/venta-estudios-zapotlanejo
+mitula,El Salto,Renta,Hacienda,https://casas.mitula.mx/casas/renta-haciendas-el-salto
+mitula,Guadalajara,Renta,Hacienda,https://casas.mitula.mx/casas/renta-haciendas-guadalajara
+mitula,Ixtlahuacán de los membrillos,Renta,Hacienda,https://casas.mitula.mx/casas/renta-haciendas-ixtlahuacan-de-los-membrillos
+mitula,Juanacatlán,Renta,Hacienda,https://casas.mitula.mx/casas/renta-haciendas-juanacatlan
+mitula,San Pedro Tlaquepaque,Renta,Hacienda,https://casas.mitula.mx/casas/renta-haciendas-san-pedro-tlaquepaque
+mitula,Tlajomulco de Zuñiga,Renta,Hacienda,https://casas.mitula.mx/casas/renta-haciendas-tlajomulco-de-zuniga
+mitula,Tonalá,Renta,Hacienda,https://casas.mitula.mx/casas/renta-haciendas-tonala
+mitula,Zapopan,Renta,Hacienda,https://casas.mitula.mx/casas/renta-haciendas-zapopan
+mitula,Zapotlanejo,Renta,Hacienda,https://casas.mitula.mx/casas/renta-haciendas-zapotlanejo
+mitula,El Salto,Venta,Hacienda,https://casas.mitula.mx/casas/venta-haciendas-el-salto
+mitula,Guadalajara,Venta,Hacienda,https://casas.mitula.mx/casas/venta-haciendas-guadalajara
+mitula,Ixtlahuacán de los membrillos,Venta,Hacienda,https://casas.mitula.mx/casas/venta-haciendas-ixtlahuacan-de-los-membrillos
+mitula,Juanacatlán,Venta,Hacienda,https://casas.mitula.mx/casas/venta-haciendas-juanacatlan
+mitula,San Pedro Tlaquepaque,Venta,Hacienda,https://casas.mitula.mx/casas/venta-haciendas-san-pedro-tlaquepaque
+mitula,Tlajomulco de Zuñiga,Venta,Hacienda,https://casas.mitula.mx/casas/venta-haciendas-tlajomulco-de-zuniga
+mitula,Tonalá,Venta,Hacienda,https://casas.mitula.mx/casas/venta-haciendas-tonala
+mitula,Zapopan,Venta,Hacienda,https://casas.mitula.mx/casas/venta-haciendas-zapopan
+mitula,Zapotlanejo,Venta,Hacienda,https://casas.mitula.mx/casas/venta-haciendas-zapotlanejo
+mitula,El Salto,Renta,Hotel,https://casas.mitula.mx/casas/renta-hoteles-el-salto
+mitula,Guadalajara,Renta,Hotel,https://casas.mitula.mx/casas/renta-hoteles-guadalajara
+mitula,Ixtlahuacán de los membrillos,Renta,Hotel,https://casas.mitula.mx/casas/renta-hoteles-ixtlahuacan-de-los-membrillos
+mitula,Juanacatlán,Renta,Hotel,https://casas.mitula.mx/casas/renta-hoteles-juanacatlan
+mitula,San Pedro Tlaquepaque,Renta,Hotel,https://casas.mitula.mx/casas/renta-hoteles-san-pedro-tlaquepaque
+mitula,Tlajomulco de Zuñiga,Renta,Hotel,https://casas.mitula.mx/casas/renta-hoteles-tlajomulco-de-zuniga
+mitula,Tonalá,Renta,Hotel,https://casas.mitula.mx/casas/renta-hoteles-tonala
+mitula,Zapopan,Renta,Hotel,https://casas.mitula.mx/casas/renta-hoteles-zapopan
+mitula,Zapotlanejo,Renta,Hotel,https://casas.mitula.mx/casas/renta-hoteles-zapotlanejo
+mitula,El Salto,Venta,Hotel,https://casas.mitula.mx/casas/venta-hoteles-el-salto
+mitula,Guadalajara,Venta,Hotel,https://casas.mitula.mx/casas/venta-hoteles-guadalajara
+mitula,Ixtlahuacán de los membrillos,Venta,Hotel,https://casas.mitula.mx/casas/venta-hoteles-ixtlahuacan-de-los-membrillos
+mitula,Juanacatlán,Venta,Hotel,https://casas.mitula.mx/casas/venta-hoteles-juanacatlan
+mitula,San Pedro Tlaquepaque,Venta,Hotel,https://casas.mitula.mx/casas/venta-hoteles-san-pedro-tlaquepaque
+mitula,Tlajomulco de Zuñiga,Venta,Hotel,https://casas.mitula.mx/casas/venta-hoteles-tlajomulco-de-zuniga
+mitula,Tonalá,Venta,Hotel,https://casas.mitula.mx/casas/venta-hoteles-tonala
+mitula,Zapopan,Venta,Hotel,https://casas.mitula.mx/casas/venta-hoteles-zapopan
+mitula,Zapotlanejo,Venta,Hotel,https://casas.mitula.mx/casas/venta-hoteles-zapotlanejo
+mitula,El Salto,Renta,Local Comercial,https://casas.mitula.mx/casas/renta-locales-comerciales-el-salto
+mitula,Guadalajara,Renta,Local Comercial,https://casas.mitula.mx/casas/renta-locales-comerciales-guadalajara
+mitula,Ixtlahuacán de los membrillos,Renta,Local Comercial,https://casas.mitula.mx/casas/renta-locales-comerciales-ixtlahuacan-de-los-membrillos
+mitula,Juanacatlán,Renta,Local Comercial,https://casas.mitula.mx/casas/renta-locales-comerciales-juanacatlan
+mitula,San Pedro Tlaquepaque,Renta,Local Comercial,https://casas.mitula.mx/casas/renta-locales-comerciales-san-pedro-tlaquepaque
+mitula,Tlajomulco de Zuñiga,Renta,Local Comercial,https://casas.mitula.mx/casas/renta-locales-comerciales-tlajomulco-de-zuniga
+mitula,Tonalá,Renta,Local Comercial,https://casas.mitula.mx/casas/renta-locales-comerciales-tonala
+mitula,Zapopan,Renta,Local Comercial,https://casas.mitula.mx/casas/renta-locales-comerciales-zapopan
+mitula,Zapotlanejo,Renta,Local Comercial,https://casas.mitula.mx/casas/renta-locales-comerciales-zapotlanejo
+mitula,El Salto,Venta,Local Comercial,https://casas.mitula.mx/casas/venta-locales-comerciales-el-salto
+mitula,Guadalajara,Venta,Local Comercial,https://casas.mitula.mx/casas/venta-locales-comerciales-guadalajara
+mitula,Ixtlahuacán de los membrillos,Venta,Local Comercial,https://casas.mitula.mx/casas/venta-locales-comerciales-ixtlahuacan-de-los-membrillos
+mitula,Juanacatlán,Venta,Local Comercial,https://casas.mitula.mx/casas/venta-locales-comerciales-juanacatlan
+mitula,San Pedro Tlaquepaque,Venta,Local Comercial,https://casas.mitula.mx/casas/venta-locales-comerciales-san-pedro-tlaquepaque
+mitula,Tlajomulco de Zuñiga,Venta,Local Comercial,https://casas.mitula.mx/casas/venta-locales-comerciales-tlajomulco-de-zuniga
+mitula,Tonalá,Venta,Local Comercial,https://casas.mitula.mx/casas/venta-locales-comerciales-tonala
+mitula,Zapopan,Venta,Local Comercial,https://casas.mitula.mx/casas/venta-locales-comerciales-zapopan
+mitula,Zapotlanejo,Venta,Local Comercial,https://casas.mitula.mx/casas/venta-locales-comerciales-zapotlanejo
+mitula,El Salto,Renta,Local en Centro Comercial,https://casas.mitula.mx/casas/renta-locales-en-centro-comercial-el-salto
+mitula,Guadalajara,Renta,Local en Centro Comercial,https://casas.mitula.mx/casas/renta-locales-en-centro-comercial-guadalajara
+mitula,Ixtlahuacán de los membrillos,Renta,Local en Centro Comercial,https://casas.mitula.mx/casas/renta-locales-en-centro-comercial-ixtlahuacan-de-los-membrillos
+mitula,Juanacatlán,Renta,Local en Centro Comercial,https://casas.mitula.mx/casas/renta-locales-en-centro-comercial-juanacatlan
+mitula,San Pedro Tlaquepaque,Renta,Local en Centro Comercial,https://casas.mitula.mx/casas/renta-locales-en-centro-comercial-san-pedro-tlaquepaque
+mitula,Tlajomulco de Zuñiga,Renta,Local en Centro Comercial,https://casas.mitula.mx/casas/renta-locales-en-centro-comercial-tlajomulco-de-zuniga
+mitula,Tonalá,Renta,Local en Centro Comercial,https://casas.mitula.mx/casas/renta-locales-en-centro-comercial-tonala
+mitula,Zapopan,Renta,Local en Centro Comercial,https://casas.mitula.mx/casas/renta-locales-en-centro-comercial-zapopan
+mitula,Zapotlanejo,Renta,Local en Centro Comercial,https://casas.mitula.mx/casas/renta-locales-en-centro-comercial-zapotlanejo
+mitula,El Salto,Venta,Local en Centro Comercial,https://casas.mitula.mx/casas/venta-locales-en-centro-comercial-el-salto
+mitula,Guadalajara,Venta,Local en Centro Comercial,https://casas.mitula.mx/casas/venta-locales-en-centro-comercial-guadalajara
+mitula,Ixtlahuacán de los membrillos,Venta,Local en Centro Comercial,https://casas.mitula.mx/casas/venta-locales-en-centro-comercial-ixtlahuacan-de-los-membrillos
+mitula,Juanacatlán,Venta,Local en Centro Comercial,https://casas.mitula.mx/casas/venta-locales-en-centro-comercial-juanacatlan
+mitula,San Pedro Tlaquepaque,Venta,Local en Centro Comercial,https://casas.mitula.mx/casas/venta-locales-en-centro-comercial-san-pedro-tlaquepaque
+mitula,Tlajomulco de Zuñiga,Venta,Local en Centro Comercial,https://casas.mitula.mx/casas/venta-locales-en-centro-comercial-tlajomulco-de-zuniga
+mitula,Tonalá,Venta,Local en Centro Comercial,https://casas.mitula.mx/casas/venta-locales-en-centro-comercial-tonala
+mitula,Zapopan,Venta,Local en Centro Comercial,https://casas.mitula.mx/casas/venta-locales-en-centro-comercial-zapopan
+mitula,Zapotlanejo,Venta,Local en Centro Comercial,https://casas.mitula.mx/casas/venta-locales-en-centro-comercial-zapotlanejo
+mitula,El Salto,Renta,Nave Industrial,https://casas.mitula.mx/casas/renta-naves-industriales-el-salto
+mitula,Guadalajara,Renta,Nave Industrial,https://casas.mitula.mx/casas/renta-naves-industriales-guadalajara
+mitula,Ixtlahuacán de los membrillos,Renta,Nave Industrial,https://casas.mitula.mx/casas/renta-naves-industriales-ixtlahuacan-de-los-membrillos
+mitula,Juanacatlán,Renta,Nave Industrial,https://casas.mitula.mx/casas/renta-naves-industriales-juanacatlan
+mitula,San Pedro Tlaquepaque,Renta,Nave Industrial,https://casas.mitula.mx/casas/renta-naves-industriales-san-pedro-tlaquepaque
+mitula,Tlajomulco de Zuñiga,Renta,Nave Industrial,https://casas.mitula.mx/casas/renta-naves-industriales-tlajomulco-de-zuniga
+mitula,Tonalá,Renta,Nave Industrial,https://casas.mitula.mx/casas/renta-naves-industriales-tonala
+mitula,Zapopan,Renta,Nave Industrial,https://casas.mitula.mx/casas/renta-naves-industriales-zapopan
+mitula,Zapotlanejo,Renta,Nave Industrial,https://casas.mitula.mx/casas/renta-naves-industriales-zapotlanejo
+mitula,El Salto,Venta,Nave Industrial,https://casas.mitula.mx/casas/venta-naves-industriales-el-salto
+mitula,Guadalajara,Venta,Nave Industrial,https://casas.mitula.mx/casas/venta-naves-industriales-guadalajara
+mitula,Ixtlahuacán de los membrillos,Venta,Nave Industrial,https://casas.mitula.mx/casas/venta-naves-industriales-ixtlahuacan-de-los-membrillos
+mitula,Juanacatlán,Venta,Nave Industrial,https://casas.mitula.mx/casas/venta-naves-industriales-juanacatlan
+mitula,San Pedro Tlaquepaque,Venta,Nave Industrial,https://casas.mitula.mx/casas/venta-naves-industriales-san-pedro-tlaquepaque
+mitula,Tlajomulco de Zuñiga,Venta,Nave Industrial,https://casas.mitula.mx/casas/venta-naves-industriales-tlajomulco-de-zuniga
+mitula,Tonalá,Venta,Nave Industrial,https://casas.mitula.mx/casas/venta-naves-industriales-tonala
+mitula,Zapopan,Venta,Nave Industrial,https://casas.mitula.mx/casas/venta-naves-industriales-zapopan
+mitula,Zapotlanejo,Venta,Nave Industrial,https://casas.mitula.mx/casas/venta-naves-industriales-zapotlanejo
+mitula,El Salto,Renta,Oficina,https://casas.mitula.mx/casas/renta-oficinas-el-salto
+mitula,Guadalajara,Renta,Oficina,https://casas.mitula.mx/casas/renta-oficinas-guadalajara
+mitula,Ixtlahuacán de los membrillos,Renta,Oficina,https://casas.mitula.mx/casas/renta-oficinas-ixtlahuacan-de-los-membrillos
+mitula,Juanacatlán,Renta,Oficina,https://casas.mitula.mx/casas/renta-oficinas-juanacatlan
+mitula,San Pedro Tlaquepaque,Renta,Oficina,https://casas.mitula.mx/casas/renta-oficinas-san-pedro-tlaquepaque
+mitula,Tlajomulco de Zuñiga,Renta,Oficina,https://casas.mitula.mx/casas/renta-oficinas-tlajomulco-de-zuniga
+mitula,Tonalá,Renta,Oficina,https://casas.mitula.mx/casas/renta-oficinas-tonala
+mitula,Zapopan,Renta,Oficina,https://casas.mitula.mx/casas/renta-oficinas-zapopan
+mitula,Zapotlanejo,Renta,Oficina,https://casas.mitula.mx/casas/renta-oficinas-zapotlanejo
+mitula,El Salto,Venta,Oficina,https://casas.mitula.mx/casas/venta-oficinas-el-salto
+mitula,Guadalajara,Venta,Oficina,https://casas.mitula.mx/casas/venta-oficinas-guadalajara
+mitula,Ixtlahuacán de los membrillos,Venta,Oficina,https://casas.mitula.mx/casas/venta-oficinas-ixtlahuacan-de-los-membrillos
+mitula,Juanacatlán,Venta,Oficina,https://casas.mitula.mx/casas/venta-oficinas-juanacatlan
+mitula,San Pedro Tlaquepaque,Venta,Oficina,https://casas.mitula.mx/casas/venta-oficinas-san-pedro-tlaquepaque
+mitula,Tlajomulco de Zuñiga,Venta,Oficina,https://casas.mitula.mx/casas/venta-oficinas-tlajomulco-de-zuniga
+mitula,Tonalá,Venta,Oficina,https://casas.mitula.mx/casas/venta-oficinas-tonala
+mitula,Zapopan,Venta,Oficina,https://casas.mitula.mx/casas/venta-oficinas-zapopan
+mitula,Zapotlanejo,Venta,Oficina,https://casas.mitula.mx/casas/venta-oficinas-zapotlanejo
+mitula,El Salto,Renta,Parcela,https://casas.mitula.mx/casas/renta-parcelas-el-salto
+mitula,Guadalajara,Renta,Parcela,https://casas.mitula.mx/casas/renta-parcelas-guadalajara
+mitula,Ixtlahuacán de los membrillos,Renta,Parcela,https://casas.mitula.mx/casas/renta-parcelas-ixtlahuacan-de-los-membrillos
+mitula,Juanacatlán,Renta,Parcela,https://casas.mitula.mx/casas/renta-parcelas-juanacatlan
+mitula,San Pedro Tlaquepaque,Renta,Parcela,https://casas.mitula.mx/casas/renta-parcelas-san-pedro-tlaquepaque
+mitula,Tlajomulco de Zuñiga,Renta,Parcela,https://casas.mitula.mx/casas/renta-parcelas-tlajomulco-de-zuniga
+mitula,Tonalá,Renta,Parcela,https://casas.mitula.mx/casas/renta-parcelas-tonala
+mitula,Zapopan,Renta,Parcela,https://casas.mitula.mx/casas/renta-parcelas-zapopan
+mitula,Zapotlanejo,Renta,Parcela,https://casas.mitula.mx/casas/renta-parcelas-zapotlanejo
+mitula,El Salto,Venta,Parcela,https://casas.mitula.mx/casas/venta-parcelas-el-salto
+mitula,Guadalajara,Venta,Parcela,https://casas.mitula.mx/casas/venta-parcelas-guadalajara
+mitula,Ixtlahuacán de los membrillos,Venta,Parcela,https://casas.mitula.mx/casas/venta-parcelas-ixtlahuacan-de-los-membrillos
+mitula,Juanacatlán,Venta,Parcela,https://casas.mitula.mx/casas/venta-parcelas-juanacatlan
+mitula,San Pedro Tlaquepaque,Venta,Parcela,https://casas.mitula.mx/casas/venta-parcelas-san-pedro-tlaquepaque
+mitula,Tlajomulco de Zuñiga,Venta,Parcela,https://casas.mitula.mx/casas/venta-parcelas-tlajomulco-de-zuniga
+mitula,Tonalá,Venta,Parcela,https://casas.mitula.mx/casas/venta-parcelas-tonala
+mitula,Zapopan,Venta,Parcela,https://casas.mitula.mx/casas/venta-parcelas-zapopan
+mitula,Zapotlanejo,Venta,Parcela,https://casas.mitula.mx/casas/venta-parcelas-zapotlanejo
+mitula,El Salto,Renta,Penthouse,https://casas.mitula.mx/casas/renta-penthouses-el-salto
+mitula,Guadalajara,Renta,Penthouse,https://casas.mitula.mx/casas/renta-penthouses-guadalajara
+mitula,Ixtlahuacán de los membrillos,Renta,Penthouse,https://casas.mitula.mx/casas/renta-penthouses-ixtlahuacan-de-los-membrillos
+mitula,Juanacatlán,Renta,Penthouse,https://casas.mitula.mx/casas/renta-penthouses-juanacatlan
+mitula,San Pedro Tlaquepaque,Renta,Penthouse,https://casas.mitula.mx/casas/renta-penthouses-san-pedro-tlaquepaque
+mitula,Tlajomulco de Zuñiga,Renta,Penthouse,https://casas.mitula.mx/casas/renta-penthouses-tlajomulco-de-zuniga
+mitula,Tonalá,Renta,Penthouse,https://casas.mitula.mx/casas/renta-penthouses-tonala
+mitula,Zapopan,Renta,Penthouse,https://casas.mitula.mx/casas/renta-penthouses-zapopan
+mitula,Zapotlanejo,Renta,Penthouse,https://casas.mitula.mx/casas/renta-penthouses-zapotlanejo
+mitula,El Salto,Venta,Penthouse,https://casas.mitula.mx/casas/venta-penthouses-el-salto
+mitula,Guadalajara,Venta,Penthouse,https://casas.mitula.mx/casas/venta-penthouses-guadalajara
+mitula,Ixtlahuacán de los membrillos,Venta,Penthouse,https://casas.mitula.mx/casas/venta-penthouses-ixtlahuacan-de-los-membrillos
+mitula,Juanacatlán,Venta,Penthouse,https://casas.mitula.mx/casas/venta-penthouses-juanacatlan
+mitula,San Pedro Tlaquepaque,Venta,Penthouse,https://casas.mitula.mx/casas/venta-penthouses-san-pedro-tlaquepaque
+mitula,Tlajomulco de Zuñiga,Venta,Penthouse,https://casas.mitula.mx/casas/venta-penthouses-tlajomulco-de-zuniga
+mitula,Tonalá,Venta,Penthouse,https://casas.mitula.mx/casas/venta-penthouses-tonala
+mitula,Zapopan,Venta,Penthouse,https://casas.mitula.mx/casas/venta-penthouses-zapopan
+mitula,Zapotlanejo,Venta,Penthouse,https://casas.mitula.mx/casas/venta-penthouses-zapotlanejo
+mitula,El Salto,Renta,Quinta,https://casas.mitula.mx/casas/renta-quintas-el-salto
+mitula,Guadalajara,Renta,Quinta,https://casas.mitula.mx/casas/renta-quintas-guadalajara
+mitula,Ixtlahuacán de los membrillos,Renta,Quinta,https://casas.mitula.mx/casas/renta-quintas-ixtlahuacan-de-los-membrillos
+mitula,Juanacatlán,Renta,Quinta,https://casas.mitula.mx/casas/renta-quintas-juanacatlan
+mitula,San Pedro Tlaquepaque,Renta,Quinta,https://casas.mitula.mx/casas/renta-quintas-san-pedro-tlaquepaque
+mitula,Tlajomulco de Zuñiga,Renta,Quinta,https://casas.mitula.mx/casas/renta-quintas-tlajomulco-de-zuniga
+mitula,Tonalá,Renta,Quinta,https://casas.mitula.mx/casas/renta-quintas-tonala
+mitula,Zapopan,Renta,Quinta,https://casas.mitula.mx/casas/renta-quintas-zapopan
+mitula,Zapotlanejo,Renta,Quinta,https://casas.mitula.mx/casas/renta-quintas-zapotlanejo
+mitula,El Salto,Venta,Quinta,https://casas.mitula.mx/casas/venta-quintas-el-salto
+mitula,Guadalajara,Venta,Quinta,https://casas.mitula.mx/casas/venta-quintas-guadalajara
+mitula,Ixtlahuacán de los membrillos,Venta,Quinta,https://casas.mitula.mx/casas/venta-quintas-ixtlahuacan-de-los-membrillos
+mitula,Juanacatlán,Venta,Quinta,https://casas.mitula.mx/casas/venta-quintas-juanacatlan
+mitula,San Pedro Tlaquepaque,Venta,Quinta,https://casas.mitula.mx/casas/venta-quintas-san-pedro-tlaquepaque
+mitula,Tlajomulco de Zuñiga,Venta,Quinta,https://casas.mitula.mx/casas/venta-quintas-tlajomulco-de-zuniga
+mitula,Tonalá,Venta,Quinta,https://casas.mitula.mx/casas/venta-quintas-tonala
+mitula,Zapopan,Venta,Quinta,https://casas.mitula.mx/casas/venta-quintas-zapopan
+mitula,Zapotlanejo,Venta,Quinta,https://casas.mitula.mx/casas/venta-quintas-zapotlanejo
+mitula,El Salto,Renta,Rancho,https://casas.mitula.mx/casas/renta-ranchos-el-salto
+mitula,Guadalajara,Renta,Rancho,https://casas.mitula.mx/casas/renta-ranchos-guadalajara
+mitula,Ixtlahuacán de los membrillos,Renta,Rancho,https://casas.mitula.mx/casas/renta-ranchos-ixtlahuacan-de-los-membrillos
+mitula,Juanacatlán,Renta,Rancho,https://casas.mitula.mx/casas/renta-ranchos-juanacatlan
+mitula,San Pedro Tlaquepaque,Renta,Rancho,https://casas.mitula.mx/casas/renta-ranchos-san-pedro-tlaquepaque
+mitula,Tlajomulco de Zuñiga,Renta,Rancho,https://casas.mitula.mx/casas/renta-ranchos-tlajomulco-de-zuniga
+mitula,Tonalá,Renta,Rancho,https://casas.mitula.mx/casas/renta-ranchos-tonala
+mitula,Zapopan,Renta,Rancho,https://casas.mitula.mx/casas/renta-ranchos-zapopan
+mitula,Zapotlanejo,Renta,Rancho,https://casas.mitula.mx/casas/renta-ranchos-zapotlanejo
+mitula,El Salto,Venta,Rancho,https://casas.mitula.mx/casas/venta-ranchos-el-salto
+mitula,Guadalajara,Venta,Rancho,https://casas.mitula.mx/casas/venta-ranchos-guadalajara
+mitula,Ixtlahuacán de los membrillos,Venta,Rancho,https://casas.mitula.mx/casas/venta-ranchos-ixtlahuacan-de-los-membrillos
+mitula,Juanacatlán,Venta,Rancho,https://casas.mitula.mx/casas/venta-ranchos-juanacatlan
+mitula,San Pedro Tlaquepaque,Venta,Rancho,https://casas.mitula.mx/casas/venta-ranchos-san-pedro-tlaquepaque
+mitula,Tlajomulco de Zuñiga,Venta,Rancho,https://casas.mitula.mx/casas/venta-ranchos-tlajomulco-de-zuniga
+mitula,Tonalá,Venta,Rancho,https://casas.mitula.mx/casas/venta-ranchos-tonala
+mitula,Zapopan,Venta,Rancho,https://casas.mitula.mx/casas/venta-ranchos-zapopan
+mitula,Zapotlanejo,Venta,Rancho,https://casas.mitula.mx/casas/venta-ranchos-zapotlanejo
+mitula,El Salto,Renta,Terreno,https://casas.mitula.mx/casas/renta-terrenos-el-salto
+mitula,Guadalajara,Renta,Terreno,https://casas.mitula.mx/casas/renta-terrenos-guadalajara
+mitula,Ixtlahuacán de los membrillos,Renta,Terreno,https://casas.mitula.mx/casas/renta-terrenos-ixtlahuacan-de-los-membrillos
+mitula,Juanacatlán,Renta,Terreno,https://casas.mitula.mx/casas/renta-terrenos-juanacatlan
+mitula,San Pedro Tlaquepaque,Renta,Terreno,https://casas.mitula.mx/casas/renta-terrenos-san-pedro-tlaquepaque
+mitula,Tlajomulco de Zuñiga,Renta,Terreno,https://casas.mitula.mx/casas/renta-terrenos-tlajomulco-de-zuniga
+mitula,Tonalá,Renta,Terreno,https://casas.mitula.mx/casas/renta-terrenos-tonala
+mitula,Zapopan,Renta,Terreno,https://casas.mitula.mx/casas/renta-terrenos-zapopan
+mitula,Zapotlanejo,Renta,Terreno,https://casas.mitula.mx/casas/renta-terrenos-zapotlanejo
+mitula,El Salto,Venta,Terreno,https://casas.mitula.mx/casas/venta-terrenos-el-salto
+mitula,Guadalajara,Venta,Terreno,https://casas.mitula.mx/casas/venta-terrenos-guadalajara
+mitula,Ixtlahuacán de los membrillos,Venta,Terreno,https://casas.mitula.mx/casas/venta-terrenos-ixtlahuacan-de-los-membrillos
+mitula,Juanacatlán,Venta,Terreno,https://casas.mitula.mx/casas/venta-terrenos-juanacatlan
+mitula,San Pedro Tlaquepaque,Venta,Terreno,https://casas.mitula.mx/casas/venta-terrenos-san-pedro-tlaquepaque
+mitula,Tlajomulco de Zuñiga,Venta,Terreno,https://casas.mitula.mx/casas/venta-terrenos-tlajomulco-de-zuniga
+mitula,Tonalá,Venta,Terreno,https://casas.mitula.mx/casas/venta-terrenos-tonala
+mitula,Zapopan,Venta,Terreno,https://casas.mitula.mx/casas/venta-terrenos-zapopan
+mitula,Zapotlanejo,Venta,Terreno,https://casas.mitula.mx/casas/venta-terrenos-zapotlanejo
+mitula,El Salto,Renta,Villa,https://casas.mitula.mx/casas/renta-villas-el-salto
+mitula,Guadalajara,Renta,Villa,https://casas.mitula.mx/casas/renta-villas-guadalajara
+mitula,Ixtlahuacán de los membrillos,Renta,Villa,https://casas.mitula.mx/casas/renta-villas-ixtlahuacan-de-los-membrillos
+mitula,Juanacatlán,Renta,Villa,https://casas.mitula.mx/casas/renta-villas-juanacatlan
+mitula,San Pedro Tlaquepaque,Renta,Villa,https://casas.mitula.mx/casas/renta-villas-san-pedro-tlaquepaque
+mitula,Tlajomulco de Zuñiga,Renta,Villa,https://casas.mitula.mx/casas/renta-villas-tlajomulco-de-zuniga
+mitula,Tonalá,Renta,Villa,https://casas.mitula.mx/casas/renta-villas-tonala
+mitula,Zapopan,Renta,Villa,https://casas.mitula.mx/casas/renta-villas-zapopan
+mitula,Zapotlanejo,Renta,Villa,https://casas.mitula.mx/casas/renta-villas-zapotlanejo
+mitula,El Salto,Venta,Villa,https://casas.mitula.mx/casas/venta-villas-el-salto
+mitula,Guadalajara,Venta,Villa,https://casas.mitula.mx/casas/venta-villas-guadalajara
+mitula,Ixtlahuacán de los membrillos,Venta,Villa,https://casas.mitula.mx/casas/venta-villas-ixtlahuacan-de-los-membrillos
+mitula,Juanacatlán,Venta,Villa,https://casas.mitula.mx/casas/venta-villas-juanacatlan
+mitula,San Pedro Tlaquepaque,Venta,Villa,https://casas.mitula.mx/casas/venta-villas-san-pedro-tlaquepaque
+mitula,Tlajomulco de Zuñiga,Venta,Villa,https://casas.mitula.mx/casas/venta-villas-tlajomulco-de-zuniga
+mitula,Tonalá,Venta,Villa,https://casas.mitula.mx/casas/venta-villas-tonala
+mitula,Zapopan,Venta,Villa,https://casas.mitula.mx/casas/venta-villas-zapopan
+mitula,Zapotlanejo,Venta,Villa,https://casas.mitula.mx/casas/venta-villas-zapotlanejo

--- a/URLs/prop_urls.csv
+++ b/URLs/prop_urls.csv
@@ -1,254 +1,253 @@
-# Formato: PaginaWeb,Ciudad,Operación,ProductoPaginaWeb,URL
-PaginaWeb,Ciudad,Operación,ProductoPaginaWeb,URL,ago25_2,sep25_1,sep25_2,oct25_1,oct25_2,nov25_1,nov25_2,dic25_1,dic25_2,ene25_1,ene25_2,feb25_1,feb25_2,mar25_1,mar25_2,abr25_1,abr25_2,may25_1,may25_2,jun25_1,jun25_2,jul25_1,jul25_2,ago25_1,ago25_2,sep25_1,sep25_2
-propiedades.com,Zapopan,Rentar,Terrenos Industriales,https://propiedades.com/zapopan/terrenos-industriales-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Zapopan,Comprar,Terrenos Industriales,https://propiedades.com/zapopan/terrenos-industriales-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Guadalajara,Rentar,Terrenos Industriales,https://propiedades.com/guadalajara/terrenos-industriales-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Guadalajara,Comprar,Terrenos Industriales,https://propiedades.com/guadalajara/terrenos-industriales-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,San Pedro Tlaquepaque,Rentar,Terrenos Industriales,https://propiedades.com/san-pedro-tlaquepaque/terrenos-industriales-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,San Pedro Tlaquepaque,Comprar,Terrenos Industriales,https://propiedades.com/san-pedro-tlaquepaque/terrenos-industriales-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,TonalÃ¡,Rentar,Terrenos Industriales,https://propiedades.com/tonala-jalisco/terrenos-industriales-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,TonalÃ¡,Comprar,Terrenos Industriales,https://propiedades.com/tonala-jalisco/terrenos-industriales-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Zapotlanejo,Rentar,Terrenos Industriales,https://propiedades.com/zapotlanejo/terrenos-industriales-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Zapotlanejo,Comprar,Terrenos Industriales,https://propiedades.com/zapotlanejo/terrenos-industriales-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,JuanacatlÃ¡n,Rentar,Terrenos Industriales,https://propiedades.com/juanacatlan/terrenos-industriales-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,JuanacatlÃ¡n,Comprar,Terrenos Industriales,https://propiedades.com/juanacatlan/terrenos-industriales-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,IxtlahuacÃ¡n de los Membrillos,Rentar,Terrenos Industriales,https://propiedades.com/ixtlahuacan-de-los-membrillos/terrenos-industriales-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,IxtlahuacÃ¡n de los Membrillos,Comprar,Terrenos Industriales,https://propiedades.com/ixtlahuacan-de-los-membrillos/terrenos-industriales-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,El Salto,Rentar,Terrenos Industriales,https://propiedades.com/el-salto/terrenos-industriales-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,El Salto,Comprar,Terrenos Industriales,https://propiedades.com/el-salto/terrenos-industriales-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Tlajomulco de ZÃºÃ±iga,Rentar,Terrenos Industriales,https://propiedades.com/tlajomulco-de-zuniga/terrenos-industriales-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Tlajomulco de ZÃºÃ±iga,Comprar,Terrenos Industriales,https://propiedades.com/tlajomulco-de-zuniga/terrenos-industriales-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Zapopan,Rentar,Terrenos Habitacionales,https://propiedades.com/zapopan/terrenos-habitacionales-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Zapopan,Comprar,Terrenos Habitacionales,https://propiedades.com/zapopan/terrenos-habitacionales-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Guadalajara,Rentar,Terrenos Habitacionales,https://propiedades.com/guadalajara/terrenos-habitacionales-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Guadalajara,Comprar,Terrenos Habitacionales,https://propiedades.com/guadalajara/terrenos-habitacionales-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,San Pedro Tlaquepaque,Rentar,Terrenos Habitacionales,https://propiedades.com/san-pedro-tlaquepaque/terrenos-habitacionales-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,San Pedro Tlaquepaque,Comprar,Terrenos Habitacionales,https://propiedades.com/san-pedro-tlaquepaque/terrenos-habitacionales-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,TonalÃ¡,Rentar,Terrenos Habitacionales,https://propiedades.com/tonala-jalisco/terrenos-habitacionales-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,TonalÃ¡,Comprar,Terrenos Habitacionales,https://propiedades.com/tonala-jalisco/terrenos-habitacionales-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Zapotlanejo,Rentar,Terrenos Habitacionales,https://propiedades.com/zapotlanejo/terrenos-habitacionales-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Zapotlanejo,Comprar,Terrenos Habitacionales,https://propiedades.com/zapotlanejo/terrenos-habitacionales-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,JuanacatlÃ¡n,Rentar,Terrenos Habitacionales,https://propiedades.com/juanacatlan/terrenos-habitacionales-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,JuanacatlÃ¡n,Comprar,Terrenos Habitacionales,https://propiedades.com/juanacatlan/terrenos-habitacionales-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,IxtlahuacÃ¡n de los Membrillos,Rentar,Terrenos Habitacionales,https://propiedades.com/ixtlahuacan-de-los-membrillos/terrenos-habitacionales-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,IxtlahuacÃ¡n de los Membrillos,Comprar,Terrenos Habitacionales,https://propiedades.com/ixtlahuacan-de-los-membrillos/terrenos-habitacionales-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,El Salto,Rentar,Terrenos Habitacionales,https://propiedades.com/el-salto/terrenos-habitacionales-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,El Salto,Comprar,Terrenos Habitacionales,https://propiedades.com/el-salto/terrenos-habitacionales-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Tlajomulco de ZÃºÃ±iga,Rentar,Terrenos Habitacionales,https://propiedades.com/tlajomulco-de-zuniga/terrenos-habitacionales-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Tlajomulco de ZÃºÃ±iga,Comprar,Terrenos Habitacionales,https://propiedades.com/tlajomulco-de-zuniga/terrenos-habitacionales-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Zapopan,Rentar,Terrenos Comerciales,https://propiedades.com/zapopan/terrenos-comerciales-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Zapopan,Comprar,Terrenos Comerciales,https://propiedades.com/zapopan/terrenos-comerciales-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Guadalajara,Rentar,Terrenos Comerciales,https://propiedades.com/guadalajara/terrenos-comerciales-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Guadalajara,Comprar,Terrenos Comerciales,https://propiedades.com/guadalajara/terrenos-comerciales-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,San Pedro Tlaquepaque,Rentar,Terrenos Comerciales,https://propiedades.com/san-pedro-tlaquepaque/terrenos-comerciales-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,San Pedro Tlaquepaque,Comprar,Terrenos Comerciales,https://propiedades.com/san-pedro-tlaquepaque/terrenos-comerciales-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,TonalÃ¡,Rentar,Terrenos Comerciales,https://propiedades.com/tonala-jalisco/terrenos-comerciales-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,TonalÃ¡,Comprar,Terrenos Comerciales,https://propiedades.com/tonala-jalisco/terrenos-comerciales-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Zapotlanejo,Rentar,Terrenos Comerciales,https://propiedades.com/zapotlanejo/terrenos-comerciales-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Zapotlanejo,Comprar,Terrenos Comerciales,https://propiedades.com/zapotlanejo/terrenos-comerciales-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,JuanacatlÃ¡n,Rentar,Terrenos Comerciales,https://propiedades.com/juanacatlan/terrenos-comerciales-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,JuanacatlÃ¡n,Comprar,Terrenos Comerciales,https://propiedades.com/juanacatlan/terrenos-comerciales-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,IxtlahuacÃ¡n de los Membrillos,Rentar,Terrenos Comerciales,https://propiedades.com/ixtlahuacan-de-los-membrillos/terrenos-comerciales-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,IxtlahuacÃ¡n de los Membrillos,Comprar,Terrenos Comerciales,https://propiedades.com/ixtlahuacan-de-los-membrillos/terrenos-comerciales-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,El Salto,Rentar,Terrenos Comerciales,https://propiedades.com/el-salto/terrenos-comerciales-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,El Salto,Comprar,Terrenos Comerciales,https://propiedades.com/el-salto/terrenos-comerciales-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Tlajomulco de ZÃºÃ±iga,Rentar,Terrenos Comerciales,https://propiedades.com/tlajomulco-de-zuniga/terrenos-comerciales-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Tlajomulco de ZÃºÃ±iga,Comprar,Terrenos Comerciales,https://propiedades.com/tlajomulco-de-zuniga/terrenos-comerciales-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Zapopan,Rentar,Ranchos,https://propiedades.com/zapopan/ranchos-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Zapopan,Comprar,Ranchos,https://propiedades.com/zapopan/ranchos-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Guadalajara,Rentar,Ranchos,https://propiedades.com/guadalajara/ranchos-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Guadalajara,Comprar,Ranchos,https://propiedades.com/guadalajara/ranchos-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,San Pedro Tlaquepaque,Rentar,Ranchos,https://propiedades.com/san-pedro-tlaquepaque/ranchos-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,San Pedro Tlaquepaque,Comprar,Ranchos,https://propiedades.com/san-pedro-tlaquepaque/ranchos-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,TonalÃ¡,Rentar,Ranchos,https://propiedades.com/tonala-jalisco/ranchos-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,TonalÃ¡,Comprar,Ranchos,https://propiedades.com/tonala-jalisco/ranchos-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Zapotlanejo,Rentar,Ranchos,https://propiedades.com/zapotlanejo/ranchos-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Zapotlanejo,Comprar,Ranchos,https://propiedades.com/zapotlanejo/ranchos-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,JuanacatlÃ¡n,Rentar,Ranchos,https://propiedades.com/juanacatlan/ranchos-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,JuanacatlÃ¡n,Comprar,Ranchos,https://propiedades.com/juanacatlan/ranchos-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,IxtlahuacÃ¡n de los Membrillos,Rentar,Ranchos,https://propiedades.com/ixtlahuacan-de-los-membrillos/ranchos-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,IxtlahuacÃ¡n de los Membrillos,Comprar,Ranchos,https://propiedades.com/ixtlahuacan-de-los-membrillos/ranchos-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,El Salto,Rentar,Ranchos,https://propiedades.com/el-salto/ranchos-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,El Salto,Comprar,Ranchos,https://propiedades.com/el-salto/ranchos-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Tlajomulco de ZÃºÃ±iga,Rentar,Ranchos,https://propiedades.com/tlajomulco-de-zuniga/ranchos-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Tlajomulco de ZÃºÃ±iga,Comprar,Ranchos,https://propiedades.com/tlajomulco-de-zuniga/ranchos-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Zapopan,Rentar,Oficinas,https://propiedades.com/zapopan/oficinas-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Zapopan,Comprar,Oficinas,https://propiedades.com/zapopan/oficinas-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Guadalajara,Rentar,Oficinas,https://propiedades.com/guadalajara/oficinas-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Guadalajara,Comprar,Oficinas,https://propiedades.com/guadalajara/oficinas-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,San Pedro Tlaquepaque,Rentar,Oficinas,https://propiedades.com/san-pedro-tlaquepaque/oficinas-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,San Pedro Tlaquepaque,Comprar,Oficinas,https://propiedades.com/san-pedro-tlaquepaque/oficinas-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,TonalÃ¡,Rentar,Oficinas,https://propiedades.com/tonala-jalisco/oficinas-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,TonalÃ¡,Comprar,Oficinas,https://propiedades.com/tonala-jalisco/oficinas-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Zapotlanejo,Rentar,Oficinas,https://propiedades.com/zapotlanejo/oficinas-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Zapotlanejo,Comprar,Oficinas,https://propiedades.com/zapotlanejo/oficinas-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,JuanacatlÃ¡n,Rentar,Oficinas,https://propiedades.com/juanacatlan/oficinas-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,JuanacatlÃ¡n,Comprar,Oficinas,https://propiedades.com/juanacatlan/oficinas-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,IxtlahuacÃ¡n de los Membrillos,Rentar,Oficinas,https://propiedades.com/ixtlahuacan-de-los-membrillos/oficinas-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,IxtlahuacÃ¡n de los Membrillos,Comprar,Oficinas,https://propiedades.com/ixtlahuacan-de-los-membrillos/oficinas-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,El Salto,Rentar,Oficinas,https://propiedades.com/el-salto/oficinas-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,El Salto,Comprar,Oficinas,https://propiedades.com/el-salto/oficinas-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Tlajomulco de ZÃºÃ±iga,Rentar,Oficinas,https://propiedades.com/tlajomulco-de-zuniga/oficinas-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Tlajomulco de ZÃºÃ±iga,Comprar,Oficinas,https://propiedades.com/tlajomulco-de-zuniga/oficinas-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Zapopan,Rentar,Naves Industriales,https://propiedades.com/zapopan/naves-industriales-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Zapopan,Comprar,Naves Industriales,https://propiedades.com/zapopan/naves-industriales-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Guadalajara,Rentar,Naves Industriales,https://propiedades.com/guadalajara/naves-industriales-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Guadalajara,Comprar,Naves Industriales,https://propiedades.com/guadalajara/naves-industriales-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,San Pedro Tlaquepaque,Rentar,Naves Industriales,https://propiedades.com/san-pedro-tlaquepaque/naves-industriales-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,San Pedro Tlaquepaque,Comprar,Naves Industriales,https://propiedades.com/san-pedro-tlaquepaque/naves-industriales-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,TonalÃ¡,Rentar,Naves Industriales,https://propiedades.com/tonala-jalisco/naves-industriales-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,TonalÃ¡,Comprar,Naves Industriales,https://propiedades.com/tonala-jalisco/naves-industriales-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Zapotlanejo,Rentar,Naves Industriales,https://propiedades.com/zapotlanejo/naves-industriales-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Zapotlanejo,Comprar,Naves Industriales,https://propiedades.com/zapotlanejo/naves-industriales-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,JuanacatlÃ¡n,Rentar,Naves Industriales,https://propiedades.com/juanacatlan/naves-industriales-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,JuanacatlÃ¡n,Comprar,Naves Industriales,https://propiedades.com/juanacatlan/naves-industriales-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,IxtlahuacÃ¡n de los Membrillos,Rentar,Naves Industriales,https://propiedades.com/ixtlahuacan-de-los-membrillos/naves-industriales-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,IxtlahuacÃ¡n de los Membrillos,Comprar,Naves Industriales,https://propiedades.com/ixtlahuacan-de-los-membrillos/naves-industriales-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,El Salto,Rentar,Naves Industriales,https://propiedades.com/el-salto/naves-industriales-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,El Salto,Comprar,Naves Industriales,https://propiedades.com/el-salto/naves-industriales-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Tlajomulco de ZÃºÃ±iga,Rentar,Naves Industriales,https://propiedades.com/tlajomulco-de-zuniga/naves-industriales-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Tlajomulco de ZÃºÃ±iga,Comprar,Naves Industriales,https://propiedades.com/tlajomulco-de-zuniga/naves-industriales-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Zapopan,Rentar,Locales,https://propiedades.com/zapopan/locales-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Zapopan,Comprar,Locales,https://propiedades.com/zapopan/locales-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Guadalajara,Rentar,Locales,https://propiedades.com/guadalajara/locales-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Guadalajara,Comprar,Locales,https://propiedades.com/guadalajara/locales-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,San Pedro Tlaquepaque,Rentar,Locales,https://propiedades.com/san-pedro-tlaquepaque/locales-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,San Pedro Tlaquepaque,Comprar,Locales,https://propiedades.com/san-pedro-tlaquepaque/locales-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,TonalÃ¡,Rentar,Locales,https://propiedades.com/tonala-jalisco/locales-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,TonalÃ¡,Comprar,Locales,https://propiedades.com/tonala-jalisco/locales-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Zapotlanejo,Rentar,Locales,https://propiedades.com/zapotlanejo/locales-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Zapotlanejo,Comprar,Locales,https://propiedades.com/zapotlanejo/locales-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,JuanacatlÃ¡n,Rentar,Locales,https://propiedades.com/juanacatlan/locales-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,JuanacatlÃ¡n,Comprar,Locales,https://propiedades.com/juanacatlan/locales-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,IxtlahuacÃ¡n de los Membrillos,Rentar,Locales,https://propiedades.com/ixtlahuacan-de-los-membrillos/locales-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,IxtlahuacÃ¡n de los Membrillos,Comprar,Locales,https://propiedades.com/ixtlahuacan-de-los-membrillos/locales-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,El Salto,Rentar,Locales,https://propiedades.com/el-salto/locales-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,El Salto,Comprar,Locales,https://propiedades.com/el-salto/locales-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Tlajomulco de ZÃºÃ±iga,Rentar,Locales,https://propiedades.com/tlajomulco-de-zuniga/locales-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Tlajomulco de ZÃºÃ±iga,Comprar,Locales,https://propiedades.com/tlajomulco-de-zuniga/locales-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Zapopan,Rentar,Edificios,https://propiedades.com/zapopan/edificios-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Zapopan,Comprar,Edificios,https://propiedades.com/zapopan/edificios-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Guadalajara,Rentar,Edificios,https://propiedades.com/guadalajara/edificios-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Guadalajara,Comprar,Edificios,https://propiedades.com/guadalajara/edificios-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,San Pedro Tlaquepaque,Rentar,Edificios,https://propiedades.com/san-pedro-tlaquepaque/edificios-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,San Pedro Tlaquepaque,Comprar,Edificios,https://propiedades.com/san-pedro-tlaquepaque/edificios-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,TonalÃ¡,Rentar,Edificios,https://propiedades.com/tonala-jalisco/edificios-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,TonalÃ¡,Comprar,Edificios,https://propiedades.com/tonala-jalisco/edificios-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Zapotlanejo,Rentar,Edificios,https://propiedades.com/zapotlanejo/edificios-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Zapotlanejo,Comprar,Edificios,https://propiedades.com/zapotlanejo/edificios-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,JuanacatlÃ¡n,Rentar,Edificios,https://propiedades.com/juanacatlan/edificios-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,JuanacatlÃ¡n,Comprar,Edificios,https://propiedades.com/juanacatlan/edificios-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,IxtlahuacÃ¡n de los Membrillos,Rentar,Edificios,https://propiedades.com/ixtlahuacan-de-los-membrillos/edificios-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,IxtlahuacÃ¡n de los Membrillos,Comprar,Edificios,https://propiedades.com/ixtlahuacan-de-los-membrillos/edificios-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,El Salto,Rentar,Edificios,https://propiedades.com/el-salto/edificios-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,El Salto,Comprar,Edificios,https://propiedades.com/el-salto/edificios-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Tlajomulco de ZÃºÃ±iga,Rentar,Edificios,https://propiedades.com/tlajomulco-de-zuniga/edificios-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Tlajomulco de ZÃºÃ±iga,Comprar,Edificios,https://propiedades.com/tlajomulco-de-zuniga/edificios-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Zapopan,Rentar,Departamentos,https://propiedades.com/zapopan/departamentos-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Zapopan,Comprar,Departamentos,https://propiedades.com/zapopan/departamentos-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Guadalajara,Rentar,Departamentos,https://propiedades.com/guadalajara/departamentos-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Guadalajara,Comprar,Departamentos,https://propiedades.com/guadalajara/departamentos-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,San Pedro Tlaquepaque,Rentar,Departamentos,https://propiedades.com/san-pedro-tlaquepaque/departamentos-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,San Pedro Tlaquepaque,Comprar,Departamentos,https://propiedades.com/san-pedro-tlaquepaque/departamentos-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,TonalÃ¡,Rentar,Departamentos,https://propiedades.com/tonala-jalisco/departamentos-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,TonalÃ¡,Comprar,Departamentos,https://propiedades.com/tonala-jalisco/departamentos-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Zapotlanejo,Rentar,Departamentos,https://propiedades.com/zapotlanejo/departamentos-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Zapotlanejo,Comprar,Departamentos,https://propiedades.com/zapotlanejo/departamentos-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,JuanacatlÃ¡n,Rentar,Departamentos,https://propiedades.com/juanacatlan/departamentos-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,JuanacatlÃ¡n,Comprar,Departamentos,https://propiedades.com/juanacatlan/departamentos-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,IxtlahuacÃ¡n de los Membrillos,Rentar,Departamentos,https://propiedades.com/ixtlahuacan-de-los-membrillos/departamentos-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,IxtlahuacÃ¡n de los Membrillos,Comprar,Departamentos,https://propiedades.com/ixtlahuacan-de-los-membrillos/departamentos-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,El Salto,Rentar,Departamentos,https://propiedades.com/el-salto/departamentos-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,El Salto,Comprar,Departamentos,https://propiedades.com/el-salto/departamentos-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Tlajomulco de ZÃºÃ±iga,Rentar,Departamentos,https://propiedades.com/tlajomulco-de-zuniga/departamentos-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Tlajomulco de ZÃºÃ±iga,Comprar,Departamentos,https://propiedades.com/tlajomulco-de-zuniga/departamentos-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Zapopan,Rentar,Cuartos,https://propiedades.com/zapopan/cuartos-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Zapopan,Comprar,Cuartos,https://propiedades.com/zapopan/cuartos-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Guadalajara,Rentar,Cuartos,https://propiedades.com/guadalajara/cuartos-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Guadalajara,Comprar,Cuartos,https://propiedades.com/guadalajara/cuartos-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,San Pedro Tlaquepaque,Rentar,Cuartos,https://propiedades.com/san-pedro-tlaquepaque/cuartos-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,San Pedro Tlaquepaque,Comprar,Cuartos,https://propiedades.com/san-pedro-tlaquepaque/cuartos-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,TonalÃ¡,Rentar,Cuartos,https://propiedades.com/tonala-jalisco/cuartos-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,TonalÃ¡,Comprar,Cuartos,https://propiedades.com/tonala-jalisco/cuartos-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Zapotlanejo,Rentar,Cuartos,https://propiedades.com/zapotlanejo/cuartos-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Zapotlanejo,Comprar,Cuartos,https://propiedades.com/zapotlanejo/cuartos-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,JuanacatlÃ¡n,Rentar,Cuartos,https://propiedades.com/juanacatlan/cuartos-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,JuanacatlÃ¡n,Comprar,Cuartos,https://propiedades.com/juanacatlan/cuartos-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,IxtlahuacÃ¡n de los Membrillos,Rentar,Cuartos,https://propiedades.com/ixtlahuacan-de-los-membrillos/cuartos-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,IxtlahuacÃ¡n de los Membrillos,Comprar,Cuartos,https://propiedades.com/ixtlahuacan-de-los-membrillos/cuartos-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,El Salto,Rentar,Cuartos,https://propiedades.com/el-salto/cuartos-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,El Salto,Comprar,Cuartos,https://propiedades.com/el-salto/cuartos-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Tlajomulco de ZÃºÃ±iga,Rentar,Cuartos,https://propiedades.com/tlajomulco-de-zuniga/cuartos-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Tlajomulco de ZÃºÃ±iga,Comprar,Cuartos,https://propiedades.com/tlajomulco-de-zuniga/cuartos-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Zapopan,Rentar,Casas en condominio,https://propiedades.com/zapopan/casas-en-condominio-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Zapopan,Comprar,Casas en condominio,https://propiedades.com/zapopan/casas-en-condominio-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Guadalajara,Rentar,Casas en condominio,https://propiedades.com/guadalajara/casas-en-condominio-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Guadalajara,Comprar,Casas en condominio,https://propiedades.com/guadalajara/casas-en-condominio-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,San Pedro Tlaquepaque,Rentar,Casas en condominio,https://propiedades.com/san-pedro-tlaquepaque/casas-en-condominio-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,San Pedro Tlaquepaque,Comprar,Casas en condominio,https://propiedades.com/san-pedro-tlaquepaque/casas-en-condominio-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,TonalÃ¡,Rentar,Casas en condominio,https://propiedades.com/tonala-jalisco/casas-en-condominio-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,TonalÃ¡,Comprar,Casas en condominio,https://propiedades.com/tonala-jalisco/casas-en-condominio-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Zapotlanejo,Rentar,Casas en condominio,https://propiedades.com/zapotlanejo/casas-en-condominio-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Zapotlanejo,Comprar,Casas en condominio,https://propiedades.com/zapotlanejo/casas-en-condominio-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,JuanacatlÃ¡n,Rentar,Casas en condominio,https://propiedades.com/juanacatlan/casas-en-condominio-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,JuanacatlÃ¡n,Comprar,Casas en condominio,https://propiedades.com/juanacatlan/casas-en-condominio-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,IxtlahuacÃ¡n de los Membrillos,Rentar,Casas en condominio,https://propiedades.com/ixtlahuacan-de-los-membrillos/casas-en-condominio-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,IxtlahuacÃ¡n de los Membrillos,Comprar,Casas en condominio,https://propiedades.com/ixtlahuacan-de-los-membrillos/casas-en-condominio-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,El Salto,Rentar,Casas en condominio,https://propiedades.com/el-salto/casas-en-condominio-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,El Salto,Comprar,Casas en condominio,https://propiedades.com/el-salto/casas-en-condominio-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Tlajomulco de ZÃºÃ±iga,Rentar,Casas en condominio,https://propiedades.com/tlajomulco-de-zuniga/casas-en-condominio-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Tlajomulco de ZÃºÃ±iga,Comprar,Casas en condominio,https://propiedades.com/tlajomulco-de-zuniga/casas-en-condominio-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Zapopan,Rentar,Casas,https://propiedades.com/zapopan/casas-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Zapopan,Comprar,Casas,https://propiedades.com/zapopan/casas-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Guadalajara,Rentar,Casas,https://propiedades.com/guadalajara/casas-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Guadalajara,Comprar,Casas,https://propiedades.com/guadalajara/casas-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,San Pedro Tlaquepaque,Rentar,Casas,https://propiedades.com/san-pedro-tlaquepaque/casas-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,San Pedro Tlaquepaque,Comprar,Casas,https://propiedades.com/san-pedro-tlaquepaque/casas-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,TonalÃ¡,Rentar,Casas,https://propiedades.com/tonala-jalisco/casas-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,TonalÃ¡,Comprar,Casas,https://propiedades.com/tonala-jalisco/casas-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Zapotlanejo,Rentar,Casas,https://propiedades.com/zapotlanejo/casas-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Zapotlanejo,Comprar,Casas,https://propiedades.com/zapotlanejo/casas-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,JuanacatlÃ¡n,Rentar,Casas,https://propiedades.com/juanacatlan/casas-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,JuanacatlÃ¡n,Comprar,Casas,https://propiedades.com/juanacatlan/casas-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,IxtlahuacÃ¡n de los Membrillos,Rentar,Casas,https://propiedades.com/ixtlahuacan-de-los-membrillos/casas-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,IxtlahuacÃ¡n de los Membrillos,Comprar,Casas,https://propiedades.com/ixtlahuacan-de-los-membrillos/casas-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,El Salto,Rentar,Casas,https://propiedades.com/el-salto/casas-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,El Salto,Comprar,Casas,https://propiedades.com/el-salto/casas-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Tlajomulco de ZÃºÃ±iga,Rentar,Casas,https://propiedades.com/tlajomulco-de-zuniga/casas-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Tlajomulco de ZÃºÃ±iga,Comprar,Casas,https://propiedades.com/tlajomulco-de-zuniga/casas-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Zapopan,Rentar,Bodegas Industriales,https://propiedades.com/zapopan/bodegas-industriales-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Zapopan,Comprar,Bodegas Industriales,https://propiedades.com/zapopan/bodegas-industriales-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Guadalajara,Rentar,Bodegas Industriales,https://propiedades.com/guadalajara/bodegas-industriales-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Guadalajara,Comprar,Bodegas Industriales,https://propiedades.com/guadalajara/bodegas-industriales-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,San Pedro Tlaquepaque,Rentar,Bodegas Industriales,https://propiedades.com/san-pedro-tlaquepaque/bodegas-industriales-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,San Pedro Tlaquepaque,Comprar,Bodegas Industriales,https://propiedades.com/san-pedro-tlaquepaque/bodegas-industriales-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,TonalÃ¡,Rentar,Bodegas Industriales,https://propiedades.com/tonala-jalisco/bodegas-industriales-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,TonalÃ¡,Comprar,Bodegas Industriales,https://propiedades.com/tonala-jalisco/bodegas-industriales-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Zapotlanejo,Rentar,Bodegas Industriales,https://propiedades.com/zapotlanejo/bodegas-industriales-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Zapotlanejo,Comprar,Bodegas Industriales,https://propiedades.com/zapotlanejo/bodegas-industriales-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,JuanacatlÃ¡n,Rentar,Bodegas Industriales,https://propiedades.com/juanacatlan/bodegas-industriales-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,JuanacatlÃ¡n,Comprar,Bodegas Industriales,https://propiedades.com/juanacatlan/bodegas-industriales-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,IxtlahuacÃ¡n de los Membrillos,Rentar,Bodegas Industriales,https://propiedades.com/ixtlahuacan-de-los-membrillos/bodegas-industriales-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,IxtlahuacÃ¡n de los Membrillos,Comprar,Bodegas Industriales,https://propiedades.com/ixtlahuacan-de-los-membrillos/bodegas-industriales-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,El Salto,Rentar,Bodegas Industriales,https://propiedades.com/el-salto/bodegas-industriales-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,El Salto,Comprar,Bodegas Industriales,https://propiedades.com/el-salto/bodegas-industriales-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Tlajomulco de ZÃºÃ±iga,Rentar,Bodegas Industriales,https://propiedades.com/tlajomulco-de-zuniga/bodegas-industriales-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Tlajomulco de ZÃºÃ±iga,Comprar,Bodegas Industriales,https://propiedades.com/tlajomulco-de-zuniga/bodegas-industriales-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Zapopan,Rentar,Bodegas Comerciales,https://propiedades.com/zapopan/bodegas-comerciales-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Zapopan,Comprar,Bodegas Comerciales,https://propiedades.com/zapopan/bodegas-comerciales-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Guadalajara,Rentar,Bodegas Comerciales,https://propiedades.com/guadalajara/bodegas-comerciales-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Guadalajara,Comprar,Bodegas Comerciales,https://propiedades.com/guadalajara/bodegas-comerciales-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,San Pedro Tlaquepaque,Rentar,Bodegas Comerciales,https://propiedades.com/san-pedro-tlaquepaque/bodegas-comerciales-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,San Pedro Tlaquepaque,Comprar,Bodegas Comerciales,https://propiedades.com/san-pedro-tlaquepaque/bodegas-comerciales-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,TonalÃ¡,Rentar,Bodegas Comerciales,https://propiedades.com/tonala-jalisco/bodegas-comerciales-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,TonalÃ¡,Comprar,Bodegas Comerciales,https://propiedades.com/tonala-jalisco/bodegas-comerciales-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Zapotlanejo,Rentar,Bodegas Comerciales,https://propiedades.com/zapotlanejo/bodegas-comerciales-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Zapotlanejo,Comprar,Bodegas Comerciales,https://propiedades.com/zapotlanejo/bodegas-comerciales-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,JuanacatlÃ¡n,Rentar,Bodegas Comerciales,https://propiedades.com/juanacatlan/bodegas-comerciales-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,JuanacatlÃ¡n,Comprar,Bodegas Comerciales,https://propiedades.com/juanacatlan/bodegas-comerciales-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,IxtlahuacÃ¡n de los Membrillos,Rentar,Bodegas Comerciales,https://propiedades.com/ixtlahuacan-de-los-membrillos/bodegas-comerciales-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,IxtlahuacÃ¡n de los Membrillos,Comprar,Bodegas Comerciales,https://propiedades.com/ixtlahuacan-de-los-membrillos/bodegas-comerciales-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,El Salto,Rentar,Bodegas Comerciales,https://propiedades.com/el-salto/bodegas-comerciales-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,El Salto,Comprar,Bodegas Comerciales,https://propiedades.com/el-salto/bodegas-comerciales-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Tlajomulco de ZÃºÃ±iga,Rentar,Bodegas Comerciales,https://propiedades.com/tlajomulco-de-zuniga/bodegas-comerciales-renta,,,,,,,,,,,,,,,,,,,,,,,,,,,
-propiedades.com,Tlajomulco de ZÃºÃ±iga,Comprar,Bodegas Comerciales,https://propiedades.com/tlajomulco-de-zuniga/bodegas-comerciales-venta,,,,,,,,,,,,,,,,,,,,,,,,,,,
+PaginaWeb,Ciudad,Operación,ProductoPaginaWeb,URL
+propiedades.com,Zapopan,Rentar,Terrenos Industriales,https://propiedades.com/zapopan/terrenos-industriales-renta
+propiedades.com,Zapopan,Comprar,Terrenos Industriales,https://propiedades.com/zapopan/terrenos-industriales-venta
+propiedades.com,Guadalajara,Rentar,Terrenos Industriales,https://propiedades.com/guadalajara/terrenos-industriales-renta
+propiedades.com,Guadalajara,Comprar,Terrenos Industriales,https://propiedades.com/guadalajara/terrenos-industriales-venta
+propiedades.com,San Pedro Tlaquepaque,Rentar,Terrenos Industriales,https://propiedades.com/san-pedro-tlaquepaque/terrenos-industriales-renta
+propiedades.com,San Pedro Tlaquepaque,Comprar,Terrenos Industriales,https://propiedades.com/san-pedro-tlaquepaque/terrenos-industriales-venta
+propiedades.com,Tonalá,Rentar,Terrenos Industriales,https://propiedades.com/tonala-jalisco/terrenos-industriales-renta
+propiedades.com,Tonalá,Comprar,Terrenos Industriales,https://propiedades.com/tonala-jalisco/terrenos-industriales-venta
+propiedades.com,Zapotlanejo,Rentar,Terrenos Industriales,https://propiedades.com/zapotlanejo/terrenos-industriales-renta
+propiedades.com,Zapotlanejo,Comprar,Terrenos Industriales,https://propiedades.com/zapotlanejo/terrenos-industriales-venta
+propiedades.com,Juanacatlán,Rentar,Terrenos Industriales,https://propiedades.com/juanacatlan/terrenos-industriales-renta
+propiedades.com,Juanacatlán,Comprar,Terrenos Industriales,https://propiedades.com/juanacatlan/terrenos-industriales-venta
+propiedades.com,Ixtlahuacán de los Membrillos,Rentar,Terrenos Industriales,https://propiedades.com/ixtlahuacan-de-los-membrillos/terrenos-industriales-renta
+propiedades.com,Ixtlahuacán de los Membrillos,Comprar,Terrenos Industriales,https://propiedades.com/ixtlahuacan-de-los-membrillos/terrenos-industriales-venta
+propiedades.com,El Salto,Rentar,Terrenos Industriales,https://propiedades.com/el-salto/terrenos-industriales-renta
+propiedades.com,El Salto,Comprar,Terrenos Industriales,https://propiedades.com/el-salto/terrenos-industriales-venta
+propiedades.com,Tlajomulco de Zúñiga,Rentar,Terrenos Industriales,https://propiedades.com/tlajomulco-de-zuniga/terrenos-industriales-renta
+propiedades.com,Tlajomulco de Zúñiga,Comprar,Terrenos Industriales,https://propiedades.com/tlajomulco-de-zuniga/terrenos-industriales-venta
+propiedades.com,Zapopan,Rentar,Terrenos Habitacionales,https://propiedades.com/zapopan/terrenos-habitacionales-renta
+propiedades.com,Zapopan,Comprar,Terrenos Habitacionales,https://propiedades.com/zapopan/terrenos-habitacionales-venta
+propiedades.com,Guadalajara,Rentar,Terrenos Habitacionales,https://propiedades.com/guadalajara/terrenos-habitacionales-renta
+propiedades.com,Guadalajara,Comprar,Terrenos Habitacionales,https://propiedades.com/guadalajara/terrenos-habitacionales-venta
+propiedades.com,San Pedro Tlaquepaque,Rentar,Terrenos Habitacionales,https://propiedades.com/san-pedro-tlaquepaque/terrenos-habitacionales-renta
+propiedades.com,San Pedro Tlaquepaque,Comprar,Terrenos Habitacionales,https://propiedades.com/san-pedro-tlaquepaque/terrenos-habitacionales-venta
+propiedades.com,Tonalá,Rentar,Terrenos Habitacionales,https://propiedades.com/tonala-jalisco/terrenos-habitacionales-renta
+propiedades.com,Tonalá,Comprar,Terrenos Habitacionales,https://propiedades.com/tonala-jalisco/terrenos-habitacionales-venta
+propiedades.com,Zapotlanejo,Rentar,Terrenos Habitacionales,https://propiedades.com/zapotlanejo/terrenos-habitacionales-renta
+propiedades.com,Zapotlanejo,Comprar,Terrenos Habitacionales,https://propiedades.com/zapotlanejo/terrenos-habitacionales-venta
+propiedades.com,Juanacatlán,Rentar,Terrenos Habitacionales,https://propiedades.com/juanacatlan/terrenos-habitacionales-renta
+propiedades.com,Juanacatlán,Comprar,Terrenos Habitacionales,https://propiedades.com/juanacatlan/terrenos-habitacionales-venta
+propiedades.com,Ixtlahuacán de los Membrillos,Rentar,Terrenos Habitacionales,https://propiedades.com/ixtlahuacan-de-los-membrillos/terrenos-habitacionales-renta
+propiedades.com,Ixtlahuacán de los Membrillos,Comprar,Terrenos Habitacionales,https://propiedades.com/ixtlahuacan-de-los-membrillos/terrenos-habitacionales-venta
+propiedades.com,El Salto,Rentar,Terrenos Habitacionales,https://propiedades.com/el-salto/terrenos-habitacionales-renta
+propiedades.com,El Salto,Comprar,Terrenos Habitacionales,https://propiedades.com/el-salto/terrenos-habitacionales-venta
+propiedades.com,Tlajomulco de Zúñiga,Rentar,Terrenos Habitacionales,https://propiedades.com/tlajomulco-de-zuniga/terrenos-habitacionales-renta
+propiedades.com,Tlajomulco de Zúñiga,Comprar,Terrenos Habitacionales,https://propiedades.com/tlajomulco-de-zuniga/terrenos-habitacionales-venta
+propiedades.com,Zapopan,Rentar,Terrenos Comerciales,https://propiedades.com/zapopan/terrenos-comerciales-renta
+propiedades.com,Zapopan,Comprar,Terrenos Comerciales,https://propiedades.com/zapopan/terrenos-comerciales-venta
+propiedades.com,Guadalajara,Rentar,Terrenos Comerciales,https://propiedades.com/guadalajara/terrenos-comerciales-renta
+propiedades.com,Guadalajara,Comprar,Terrenos Comerciales,https://propiedades.com/guadalajara/terrenos-comerciales-venta
+propiedades.com,San Pedro Tlaquepaque,Rentar,Terrenos Comerciales,https://propiedades.com/san-pedro-tlaquepaque/terrenos-comerciales-renta
+propiedades.com,San Pedro Tlaquepaque,Comprar,Terrenos Comerciales,https://propiedades.com/san-pedro-tlaquepaque/terrenos-comerciales-venta
+propiedades.com,Tonalá,Rentar,Terrenos Comerciales,https://propiedades.com/tonala-jalisco/terrenos-comerciales-renta
+propiedades.com,Tonalá,Comprar,Terrenos Comerciales,https://propiedades.com/tonala-jalisco/terrenos-comerciales-venta
+propiedades.com,Zapotlanejo,Rentar,Terrenos Comerciales,https://propiedades.com/zapotlanejo/terrenos-comerciales-renta
+propiedades.com,Zapotlanejo,Comprar,Terrenos Comerciales,https://propiedades.com/zapotlanejo/terrenos-comerciales-venta
+propiedades.com,Juanacatlán,Rentar,Terrenos Comerciales,https://propiedades.com/juanacatlan/terrenos-comerciales-renta
+propiedades.com,Juanacatlán,Comprar,Terrenos Comerciales,https://propiedades.com/juanacatlan/terrenos-comerciales-venta
+propiedades.com,Ixtlahuacán de los Membrillos,Rentar,Terrenos Comerciales,https://propiedades.com/ixtlahuacan-de-los-membrillos/terrenos-comerciales-renta
+propiedades.com,Ixtlahuacán de los Membrillos,Comprar,Terrenos Comerciales,https://propiedades.com/ixtlahuacan-de-los-membrillos/terrenos-comerciales-venta
+propiedades.com,El Salto,Rentar,Terrenos Comerciales,https://propiedades.com/el-salto/terrenos-comerciales-renta
+propiedades.com,El Salto,Comprar,Terrenos Comerciales,https://propiedades.com/el-salto/terrenos-comerciales-venta
+propiedades.com,Tlajomulco de Zúñiga,Rentar,Terrenos Comerciales,https://propiedades.com/tlajomulco-de-zuniga/terrenos-comerciales-renta
+propiedades.com,Tlajomulco de Zúñiga,Comprar,Terrenos Comerciales,https://propiedades.com/tlajomulco-de-zuniga/terrenos-comerciales-venta
+propiedades.com,Zapopan,Rentar,Ranchos,https://propiedades.com/zapopan/ranchos-renta
+propiedades.com,Zapopan,Comprar,Ranchos,https://propiedades.com/zapopan/ranchos-venta
+propiedades.com,Guadalajara,Rentar,Ranchos,https://propiedades.com/guadalajara/ranchos-renta
+propiedades.com,Guadalajara,Comprar,Ranchos,https://propiedades.com/guadalajara/ranchos-venta
+propiedades.com,San Pedro Tlaquepaque,Rentar,Ranchos,https://propiedades.com/san-pedro-tlaquepaque/ranchos-renta
+propiedades.com,San Pedro Tlaquepaque,Comprar,Ranchos,https://propiedades.com/san-pedro-tlaquepaque/ranchos-venta
+propiedades.com,Tonalá,Rentar,Ranchos,https://propiedades.com/tonala-jalisco/ranchos-renta
+propiedades.com,Tonalá,Comprar,Ranchos,https://propiedades.com/tonala-jalisco/ranchos-venta
+propiedades.com,Zapotlanejo,Rentar,Ranchos,https://propiedades.com/zapotlanejo/ranchos-renta
+propiedades.com,Zapotlanejo,Comprar,Ranchos,https://propiedades.com/zapotlanejo/ranchos-venta
+propiedades.com,Juanacatlán,Rentar,Ranchos,https://propiedades.com/juanacatlan/ranchos-renta
+propiedades.com,Juanacatlán,Comprar,Ranchos,https://propiedades.com/juanacatlan/ranchos-venta
+propiedades.com,Ixtlahuacán de los Membrillos,Rentar,Ranchos,https://propiedades.com/ixtlahuacan-de-los-membrillos/ranchos-renta
+propiedades.com,Ixtlahuacán de los Membrillos,Comprar,Ranchos,https://propiedades.com/ixtlahuacan-de-los-membrillos/ranchos-venta
+propiedades.com,El Salto,Rentar,Ranchos,https://propiedades.com/el-salto/ranchos-renta
+propiedades.com,El Salto,Comprar,Ranchos,https://propiedades.com/el-salto/ranchos-venta
+propiedades.com,Tlajomulco de Zúñiga,Rentar,Ranchos,https://propiedades.com/tlajomulco-de-zuniga/ranchos-renta
+propiedades.com,Tlajomulco de Zúñiga,Comprar,Ranchos,https://propiedades.com/tlajomulco-de-zuniga/ranchos-venta
+propiedades.com,Zapopan,Rentar,Oficinas,https://propiedades.com/zapopan/oficinas-renta
+propiedades.com,Zapopan,Comprar,Oficinas,https://propiedades.com/zapopan/oficinas-venta
+propiedades.com,Guadalajara,Rentar,Oficinas,https://propiedades.com/guadalajara/oficinas-renta
+propiedades.com,Guadalajara,Comprar,Oficinas,https://propiedades.com/guadalajara/oficinas-venta
+propiedades.com,San Pedro Tlaquepaque,Rentar,Oficinas,https://propiedades.com/san-pedro-tlaquepaque/oficinas-renta
+propiedades.com,San Pedro Tlaquepaque,Comprar,Oficinas,https://propiedades.com/san-pedro-tlaquepaque/oficinas-venta
+propiedades.com,Tonalá,Rentar,Oficinas,https://propiedades.com/tonala-jalisco/oficinas-renta
+propiedades.com,Tonalá,Comprar,Oficinas,https://propiedades.com/tonala-jalisco/oficinas-venta
+propiedades.com,Zapotlanejo,Rentar,Oficinas,https://propiedades.com/zapotlanejo/oficinas-renta
+propiedades.com,Zapotlanejo,Comprar,Oficinas,https://propiedades.com/zapotlanejo/oficinas-venta
+propiedades.com,Juanacatlán,Rentar,Oficinas,https://propiedades.com/juanacatlan/oficinas-renta
+propiedades.com,Juanacatlán,Comprar,Oficinas,https://propiedades.com/juanacatlan/oficinas-venta
+propiedades.com,Ixtlahuacán de los Membrillos,Rentar,Oficinas,https://propiedades.com/ixtlahuacan-de-los-membrillos/oficinas-renta
+propiedades.com,Ixtlahuacán de los Membrillos,Comprar,Oficinas,https://propiedades.com/ixtlahuacan-de-los-membrillos/oficinas-venta
+propiedades.com,El Salto,Rentar,Oficinas,https://propiedades.com/el-salto/oficinas-renta
+propiedades.com,El Salto,Comprar,Oficinas,https://propiedades.com/el-salto/oficinas-venta
+propiedades.com,Tlajomulco de Zúñiga,Rentar,Oficinas,https://propiedades.com/tlajomulco-de-zuniga/oficinas-renta
+propiedades.com,Tlajomulco de Zúñiga,Comprar,Oficinas,https://propiedades.com/tlajomulco-de-zuniga/oficinas-venta
+propiedades.com,Zapopan,Rentar,Naves Industriales,https://propiedades.com/zapopan/naves-industriales-renta
+propiedades.com,Zapopan,Comprar,Naves Industriales,https://propiedades.com/zapopan/naves-industriales-venta
+propiedades.com,Guadalajara,Rentar,Naves Industriales,https://propiedades.com/guadalajara/naves-industriales-renta
+propiedades.com,Guadalajara,Comprar,Naves Industriales,https://propiedades.com/guadalajara/naves-industriales-venta
+propiedades.com,San Pedro Tlaquepaque,Rentar,Naves Industriales,https://propiedades.com/san-pedro-tlaquepaque/naves-industriales-renta
+propiedades.com,San Pedro Tlaquepaque,Comprar,Naves Industriales,https://propiedades.com/san-pedro-tlaquepaque/naves-industriales-venta
+propiedades.com,Tonalá,Rentar,Naves Industriales,https://propiedades.com/tonala-jalisco/naves-industriales-renta
+propiedades.com,Tonalá,Comprar,Naves Industriales,https://propiedades.com/tonala-jalisco/naves-industriales-venta
+propiedades.com,Zapotlanejo,Rentar,Naves Industriales,https://propiedades.com/zapotlanejo/naves-industriales-renta
+propiedades.com,Zapotlanejo,Comprar,Naves Industriales,https://propiedades.com/zapotlanejo/naves-industriales-venta
+propiedades.com,Juanacatlán,Rentar,Naves Industriales,https://propiedades.com/juanacatlan/naves-industriales-renta
+propiedades.com,Juanacatlán,Comprar,Naves Industriales,https://propiedades.com/juanacatlan/naves-industriales-venta
+propiedades.com,Ixtlahuacán de los Membrillos,Rentar,Naves Industriales,https://propiedades.com/ixtlahuacan-de-los-membrillos/naves-industriales-renta
+propiedades.com,Ixtlahuacán de los Membrillos,Comprar,Naves Industriales,https://propiedades.com/ixtlahuacan-de-los-membrillos/naves-industriales-venta
+propiedades.com,El Salto,Rentar,Naves Industriales,https://propiedades.com/el-salto/naves-industriales-renta
+propiedades.com,El Salto,Comprar,Naves Industriales,https://propiedades.com/el-salto/naves-industriales-venta
+propiedades.com,Tlajomulco de Zúñiga,Rentar,Naves Industriales,https://propiedades.com/tlajomulco-de-zuniga/naves-industriales-renta
+propiedades.com,Tlajomulco de Zúñiga,Comprar,Naves Industriales,https://propiedades.com/tlajomulco-de-zuniga/naves-industriales-venta
+propiedades.com,Zapopan,Rentar,Locales,https://propiedades.com/zapopan/locales-renta
+propiedades.com,Zapopan,Comprar,Locales,https://propiedades.com/zapopan/locales-venta
+propiedades.com,Guadalajara,Rentar,Locales,https://propiedades.com/guadalajara/locales-renta
+propiedades.com,Guadalajara,Comprar,Locales,https://propiedades.com/guadalajara/locales-venta
+propiedades.com,San Pedro Tlaquepaque,Rentar,Locales,https://propiedades.com/san-pedro-tlaquepaque/locales-renta
+propiedades.com,San Pedro Tlaquepaque,Comprar,Locales,https://propiedades.com/san-pedro-tlaquepaque/locales-venta
+propiedades.com,Tonalá,Rentar,Locales,https://propiedades.com/tonala-jalisco/locales-renta
+propiedades.com,Tonalá,Comprar,Locales,https://propiedades.com/tonala-jalisco/locales-venta
+propiedades.com,Zapotlanejo,Rentar,Locales,https://propiedades.com/zapotlanejo/locales-renta
+propiedades.com,Zapotlanejo,Comprar,Locales,https://propiedades.com/zapotlanejo/locales-venta
+propiedades.com,Juanacatlán,Rentar,Locales,https://propiedades.com/juanacatlan/locales-renta
+propiedades.com,Juanacatlán,Comprar,Locales,https://propiedades.com/juanacatlan/locales-venta
+propiedades.com,Ixtlahuacán de los Membrillos,Rentar,Locales,https://propiedades.com/ixtlahuacan-de-los-membrillos/locales-renta
+propiedades.com,Ixtlahuacán de los Membrillos,Comprar,Locales,https://propiedades.com/ixtlahuacan-de-los-membrillos/locales-venta
+propiedades.com,El Salto,Rentar,Locales,https://propiedades.com/el-salto/locales-renta
+propiedades.com,El Salto,Comprar,Locales,https://propiedades.com/el-salto/locales-venta
+propiedades.com,Tlajomulco de Zúñiga,Rentar,Locales,https://propiedades.com/tlajomulco-de-zuniga/locales-renta
+propiedades.com,Tlajomulco de Zúñiga,Comprar,Locales,https://propiedades.com/tlajomulco-de-zuniga/locales-venta
+propiedades.com,Zapopan,Rentar,Edificios,https://propiedades.com/zapopan/edificios-renta
+propiedades.com,Zapopan,Comprar,Edificios,https://propiedades.com/zapopan/edificios-venta
+propiedades.com,Guadalajara,Rentar,Edificios,https://propiedades.com/guadalajara/edificios-renta
+propiedades.com,Guadalajara,Comprar,Edificios,https://propiedades.com/guadalajara/edificios-venta
+propiedades.com,San Pedro Tlaquepaque,Rentar,Edificios,https://propiedades.com/san-pedro-tlaquepaque/edificios-renta
+propiedades.com,San Pedro Tlaquepaque,Comprar,Edificios,https://propiedades.com/san-pedro-tlaquepaque/edificios-venta
+propiedades.com,Tonalá,Rentar,Edificios,https://propiedades.com/tonala-jalisco/edificios-renta
+propiedades.com,Tonalá,Comprar,Edificios,https://propiedades.com/tonala-jalisco/edificios-venta
+propiedades.com,Zapotlanejo,Rentar,Edificios,https://propiedades.com/zapotlanejo/edificios-renta
+propiedades.com,Zapotlanejo,Comprar,Edificios,https://propiedades.com/zapotlanejo/edificios-venta
+propiedades.com,Juanacatlán,Rentar,Edificios,https://propiedades.com/juanacatlan/edificios-renta
+propiedades.com,Juanacatlán,Comprar,Edificios,https://propiedades.com/juanacatlan/edificios-venta
+propiedades.com,Ixtlahuacán de los Membrillos,Rentar,Edificios,https://propiedades.com/ixtlahuacan-de-los-membrillos/edificios-renta
+propiedades.com,Ixtlahuacán de los Membrillos,Comprar,Edificios,https://propiedades.com/ixtlahuacan-de-los-membrillos/edificios-venta
+propiedades.com,El Salto,Rentar,Edificios,https://propiedades.com/el-salto/edificios-renta
+propiedades.com,El Salto,Comprar,Edificios,https://propiedades.com/el-salto/edificios-venta
+propiedades.com,Tlajomulco de Zúñiga,Rentar,Edificios,https://propiedades.com/tlajomulco-de-zuniga/edificios-renta
+propiedades.com,Tlajomulco de Zúñiga,Comprar,Edificios,https://propiedades.com/tlajomulco-de-zuniga/edificios-venta
+propiedades.com,Zapopan,Rentar,Departamentos,https://propiedades.com/zapopan/departamentos-renta
+propiedades.com,Zapopan,Comprar,Departamentos,https://propiedades.com/zapopan/departamentos-venta
+propiedades.com,Guadalajara,Rentar,Departamentos,https://propiedades.com/guadalajara/departamentos-renta
+propiedades.com,Guadalajara,Comprar,Departamentos,https://propiedades.com/guadalajara/departamentos-venta
+propiedades.com,San Pedro Tlaquepaque,Rentar,Departamentos,https://propiedades.com/san-pedro-tlaquepaque/departamentos-renta
+propiedades.com,San Pedro Tlaquepaque,Comprar,Departamentos,https://propiedades.com/san-pedro-tlaquepaque/departamentos-venta
+propiedades.com,Tonalá,Rentar,Departamentos,https://propiedades.com/tonala-jalisco/departamentos-renta
+propiedades.com,Tonalá,Comprar,Departamentos,https://propiedades.com/tonala-jalisco/departamentos-venta
+propiedades.com,Zapotlanejo,Rentar,Departamentos,https://propiedades.com/zapotlanejo/departamentos-renta
+propiedades.com,Zapotlanejo,Comprar,Departamentos,https://propiedades.com/zapotlanejo/departamentos-venta
+propiedades.com,Juanacatlán,Rentar,Departamentos,https://propiedades.com/juanacatlan/departamentos-renta
+propiedades.com,Juanacatlán,Comprar,Departamentos,https://propiedades.com/juanacatlan/departamentos-venta
+propiedades.com,Ixtlahuacán de los Membrillos,Rentar,Departamentos,https://propiedades.com/ixtlahuacan-de-los-membrillos/departamentos-renta
+propiedades.com,Ixtlahuacán de los Membrillos,Comprar,Departamentos,https://propiedades.com/ixtlahuacan-de-los-membrillos/departamentos-venta
+propiedades.com,El Salto,Rentar,Departamentos,https://propiedades.com/el-salto/departamentos-renta
+propiedades.com,El Salto,Comprar,Departamentos,https://propiedades.com/el-salto/departamentos-venta
+propiedades.com,Tlajomulco de Zúñiga,Rentar,Departamentos,https://propiedades.com/tlajomulco-de-zuniga/departamentos-renta
+propiedades.com,Tlajomulco de Zúñiga,Comprar,Departamentos,https://propiedades.com/tlajomulco-de-zuniga/departamentos-venta
+propiedades.com,Zapopan,Rentar,Cuartos,https://propiedades.com/zapopan/cuartos-renta
+propiedades.com,Zapopan,Comprar,Cuartos,https://propiedades.com/zapopan/cuartos-venta
+propiedades.com,Guadalajara,Rentar,Cuartos,https://propiedades.com/guadalajara/cuartos-renta
+propiedades.com,Guadalajara,Comprar,Cuartos,https://propiedades.com/guadalajara/cuartos-venta
+propiedades.com,San Pedro Tlaquepaque,Rentar,Cuartos,https://propiedades.com/san-pedro-tlaquepaque/cuartos-renta
+propiedades.com,San Pedro Tlaquepaque,Comprar,Cuartos,https://propiedades.com/san-pedro-tlaquepaque/cuartos-venta
+propiedades.com,Tonalá,Rentar,Cuartos,https://propiedades.com/tonala-jalisco/cuartos-renta
+propiedades.com,Tonalá,Comprar,Cuartos,https://propiedades.com/tonala-jalisco/cuartos-venta
+propiedades.com,Zapotlanejo,Rentar,Cuartos,https://propiedades.com/zapotlanejo/cuartos-renta
+propiedades.com,Zapotlanejo,Comprar,Cuartos,https://propiedades.com/zapotlanejo/cuartos-venta
+propiedades.com,Juanacatlán,Rentar,Cuartos,https://propiedades.com/juanacatlan/cuartos-renta
+propiedades.com,Juanacatlán,Comprar,Cuartos,https://propiedades.com/juanacatlan/cuartos-venta
+propiedades.com,Ixtlahuacán de los Membrillos,Rentar,Cuartos,https://propiedades.com/ixtlahuacan-de-los-membrillos/cuartos-renta
+propiedades.com,Ixtlahuacán de los Membrillos,Comprar,Cuartos,https://propiedades.com/ixtlahuacan-de-los-membrillos/cuartos-venta
+propiedades.com,El Salto,Rentar,Cuartos,https://propiedades.com/el-salto/cuartos-renta
+propiedades.com,El Salto,Comprar,Cuartos,https://propiedades.com/el-salto/cuartos-venta
+propiedades.com,Tlajomulco de Zúñiga,Rentar,Cuartos,https://propiedades.com/tlajomulco-de-zuniga/cuartos-renta
+propiedades.com,Tlajomulco de Zúñiga,Comprar,Cuartos,https://propiedades.com/tlajomulco-de-zuniga/cuartos-venta
+propiedades.com,Zapopan,Rentar,Casas en condominio,https://propiedades.com/zapopan/casas-en-condominio-renta
+propiedades.com,Zapopan,Comprar,Casas en condominio,https://propiedades.com/zapopan/casas-en-condominio-venta
+propiedades.com,Guadalajara,Rentar,Casas en condominio,https://propiedades.com/guadalajara/casas-en-condominio-renta
+propiedades.com,Guadalajara,Comprar,Casas en condominio,https://propiedades.com/guadalajara/casas-en-condominio-venta
+propiedades.com,San Pedro Tlaquepaque,Rentar,Casas en condominio,https://propiedades.com/san-pedro-tlaquepaque/casas-en-condominio-renta
+propiedades.com,San Pedro Tlaquepaque,Comprar,Casas en condominio,https://propiedades.com/san-pedro-tlaquepaque/casas-en-condominio-venta
+propiedades.com,Tonalá,Rentar,Casas en condominio,https://propiedades.com/tonala-jalisco/casas-en-condominio-renta
+propiedades.com,Tonalá,Comprar,Casas en condominio,https://propiedades.com/tonala-jalisco/casas-en-condominio-venta
+propiedades.com,Zapotlanejo,Rentar,Casas en condominio,https://propiedades.com/zapotlanejo/casas-en-condominio-renta
+propiedades.com,Zapotlanejo,Comprar,Casas en condominio,https://propiedades.com/zapotlanejo/casas-en-condominio-venta
+propiedades.com,Juanacatlán,Rentar,Casas en condominio,https://propiedades.com/juanacatlan/casas-en-condominio-renta
+propiedades.com,Juanacatlán,Comprar,Casas en condominio,https://propiedades.com/juanacatlan/casas-en-condominio-venta
+propiedades.com,Ixtlahuacán de los Membrillos,Rentar,Casas en condominio,https://propiedades.com/ixtlahuacan-de-los-membrillos/casas-en-condominio-renta
+propiedades.com,Ixtlahuacán de los Membrillos,Comprar,Casas en condominio,https://propiedades.com/ixtlahuacan-de-los-membrillos/casas-en-condominio-venta
+propiedades.com,El Salto,Rentar,Casas en condominio,https://propiedades.com/el-salto/casas-en-condominio-renta
+propiedades.com,El Salto,Comprar,Casas en condominio,https://propiedades.com/el-salto/casas-en-condominio-venta
+propiedades.com,Tlajomulco de Zúñiga,Rentar,Casas en condominio,https://propiedades.com/tlajomulco-de-zuniga/casas-en-condominio-renta
+propiedades.com,Tlajomulco de Zúñiga,Comprar,Casas en condominio,https://propiedades.com/tlajomulco-de-zuniga/casas-en-condominio-venta
+propiedades.com,Zapopan,Rentar,Casas,https://propiedades.com/zapopan/casas-renta
+propiedades.com,Zapopan,Comprar,Casas,https://propiedades.com/zapopan/casas-venta
+propiedades.com,Guadalajara,Rentar,Casas,https://propiedades.com/guadalajara/casas-renta
+propiedades.com,Guadalajara,Comprar,Casas,https://propiedades.com/guadalajara/casas-venta
+propiedades.com,San Pedro Tlaquepaque,Rentar,Casas,https://propiedades.com/san-pedro-tlaquepaque/casas-renta
+propiedades.com,San Pedro Tlaquepaque,Comprar,Casas,https://propiedades.com/san-pedro-tlaquepaque/casas-venta
+propiedades.com,Tonalá,Rentar,Casas,https://propiedades.com/tonala-jalisco/casas-renta
+propiedades.com,Tonalá,Comprar,Casas,https://propiedades.com/tonala-jalisco/casas-venta
+propiedades.com,Zapotlanejo,Rentar,Casas,https://propiedades.com/zapotlanejo/casas-renta
+propiedades.com,Zapotlanejo,Comprar,Casas,https://propiedades.com/zapotlanejo/casas-venta
+propiedades.com,Juanacatlán,Rentar,Casas,https://propiedades.com/juanacatlan/casas-renta
+propiedades.com,Juanacatlán,Comprar,Casas,https://propiedades.com/juanacatlan/casas-venta
+propiedades.com,Ixtlahuacán de los Membrillos,Rentar,Casas,https://propiedades.com/ixtlahuacan-de-los-membrillos/casas-renta
+propiedades.com,Ixtlahuacán de los Membrillos,Comprar,Casas,https://propiedades.com/ixtlahuacan-de-los-membrillos/casas-venta
+propiedades.com,El Salto,Rentar,Casas,https://propiedades.com/el-salto/casas-renta
+propiedades.com,El Salto,Comprar,Casas,https://propiedades.com/el-salto/casas-venta
+propiedades.com,Tlajomulco de Zúñiga,Rentar,Casas,https://propiedades.com/tlajomulco-de-zuniga/casas-renta
+propiedades.com,Tlajomulco de Zúñiga,Comprar,Casas,https://propiedades.com/tlajomulco-de-zuniga/casas-venta
+propiedades.com,Zapopan,Rentar,Bodegas Industriales,https://propiedades.com/zapopan/bodegas-industriales-renta
+propiedades.com,Zapopan,Comprar,Bodegas Industriales,https://propiedades.com/zapopan/bodegas-industriales-venta
+propiedades.com,Guadalajara,Rentar,Bodegas Industriales,https://propiedades.com/guadalajara/bodegas-industriales-renta
+propiedades.com,Guadalajara,Comprar,Bodegas Industriales,https://propiedades.com/guadalajara/bodegas-industriales-venta
+propiedades.com,San Pedro Tlaquepaque,Rentar,Bodegas Industriales,https://propiedades.com/san-pedro-tlaquepaque/bodegas-industriales-renta
+propiedades.com,San Pedro Tlaquepaque,Comprar,Bodegas Industriales,https://propiedades.com/san-pedro-tlaquepaque/bodegas-industriales-venta
+propiedades.com,Tonalá,Rentar,Bodegas Industriales,https://propiedades.com/tonala-jalisco/bodegas-industriales-renta
+propiedades.com,Tonalá,Comprar,Bodegas Industriales,https://propiedades.com/tonala-jalisco/bodegas-industriales-venta
+propiedades.com,Zapotlanejo,Rentar,Bodegas Industriales,https://propiedades.com/zapotlanejo/bodegas-industriales-renta
+propiedades.com,Zapotlanejo,Comprar,Bodegas Industriales,https://propiedades.com/zapotlanejo/bodegas-industriales-venta
+propiedades.com,Juanacatlán,Rentar,Bodegas Industriales,https://propiedades.com/juanacatlan/bodegas-industriales-renta
+propiedades.com,Juanacatlán,Comprar,Bodegas Industriales,https://propiedades.com/juanacatlan/bodegas-industriales-venta
+propiedades.com,Ixtlahuacán de los Membrillos,Rentar,Bodegas Industriales,https://propiedades.com/ixtlahuacan-de-los-membrillos/bodegas-industriales-renta
+propiedades.com,Ixtlahuacán de los Membrillos,Comprar,Bodegas Industriales,https://propiedades.com/ixtlahuacan-de-los-membrillos/bodegas-industriales-venta
+propiedades.com,El Salto,Rentar,Bodegas Industriales,https://propiedades.com/el-salto/bodegas-industriales-renta
+propiedades.com,El Salto,Comprar,Bodegas Industriales,https://propiedades.com/el-salto/bodegas-industriales-venta
+propiedades.com,Tlajomulco de Zúñiga,Rentar,Bodegas Industriales,https://propiedades.com/tlajomulco-de-zuniga/bodegas-industriales-renta
+propiedades.com,Tlajomulco de Zúñiga,Comprar,Bodegas Industriales,https://propiedades.com/tlajomulco-de-zuniga/bodegas-industriales-venta
+propiedades.com,Zapopan,Rentar,Bodegas Comerciales,https://propiedades.com/zapopan/bodegas-comerciales-renta
+propiedades.com,Zapopan,Comprar,Bodegas Comerciales,https://propiedades.com/zapopan/bodegas-comerciales-venta
+propiedades.com,Guadalajara,Rentar,Bodegas Comerciales,https://propiedades.com/guadalajara/bodegas-comerciales-renta
+propiedades.com,Guadalajara,Comprar,Bodegas Comerciales,https://propiedades.com/guadalajara/bodegas-comerciales-venta
+propiedades.com,San Pedro Tlaquepaque,Rentar,Bodegas Comerciales,https://propiedades.com/san-pedro-tlaquepaque/bodegas-comerciales-renta
+propiedades.com,San Pedro Tlaquepaque,Comprar,Bodegas Comerciales,https://propiedades.com/san-pedro-tlaquepaque/bodegas-comerciales-venta
+propiedades.com,Tonalá,Rentar,Bodegas Comerciales,https://propiedades.com/tonala-jalisco/bodegas-comerciales-renta
+propiedades.com,Tonalá,Comprar,Bodegas Comerciales,https://propiedades.com/tonala-jalisco/bodegas-comerciales-venta
+propiedades.com,Zapotlanejo,Rentar,Bodegas Comerciales,https://propiedades.com/zapotlanejo/bodegas-comerciales-renta
+propiedades.com,Zapotlanejo,Comprar,Bodegas Comerciales,https://propiedades.com/zapotlanejo/bodegas-comerciales-venta
+propiedades.com,Juanacatlán,Rentar,Bodegas Comerciales,https://propiedades.com/juanacatlan/bodegas-comerciales-renta
+propiedades.com,Juanacatlán,Comprar,Bodegas Comerciales,https://propiedades.com/juanacatlan/bodegas-comerciales-venta
+propiedades.com,Ixtlahuacán de los Membrillos,Rentar,Bodegas Comerciales,https://propiedades.com/ixtlahuacan-de-los-membrillos/bodegas-comerciales-renta
+propiedades.com,Ixtlahuacán de los Membrillos,Comprar,Bodegas Comerciales,https://propiedades.com/ixtlahuacan-de-los-membrillos/bodegas-comerciales-venta
+propiedades.com,El Salto,Rentar,Bodegas Comerciales,https://propiedades.com/el-salto/bodegas-comerciales-renta
+propiedades.com,El Salto,Comprar,Bodegas Comerciales,https://propiedades.com/el-salto/bodegas-comerciales-venta
+propiedades.com,Tlajomulco de Zúñiga,Rentar,Bodegas Comerciales,https://propiedades.com/tlajomulco-de-zuniga/bodegas-comerciales-renta
+propiedades.com,Tlajomulco de Zúñiga,Comprar,Bodegas Comerciales,https://propiedades.com/tlajomulco-de-zuniga/bodegas-comerciales-venta

--- a/URLs/tro_urls.csv
+++ b/URLs/tro_urls.csv
@@ -1,83 +1,82 @@
-# Formato: PaginaWeb,Ciudad,Operación,ProductoPaginaWeb,URL
-PaginaWeb,Ciudad,Operación,ProductoPaginaWeb,URL,ago25_2,sep25_1,sep25_2,oct25_1,oct25_2,nov25_1,nov25_2,dic25_1,dic25_2,ene25_1,ene25_2,feb25_1,feb25_2,mar25_1,mar25_2,abr25_1,abr25_2,may25_1,may25_2,jun25_1,jun25_2,jul25_1,jul25_2,ago25_1,ago25_2,sep25_1,sep25_2,sep25_2
-trovit,Zapopan,renta,Bodegas,https://casas.trovit.com.mx/renta-bodegas-zapopan,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-trovit,Guadalajara,renta,Bodegas,https://casas.trovit.com.mx/renta-bodegas-guadalajara,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-trovit,San Pedro Tlaquepaque,renta,Bodegas,https://casas.trovit.com.mx/renta-bodegas-san-pedro-tlaquepaque,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-trovit,TonalÃ¡,renta,Bodegas,https://casas.trovit.com.mx/renta-bodegas-tonala,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-trovit,Zapotlanejo,renta,Bodegas,https://casas.trovit.com.mx/renta-bodegas-zapotlanejo,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-trovit,JuanacatlÃ¡n,renta,Bodegas,https://casas.trovit.com.mx/renta-bodegas-juanacatlan,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-trovit,IxtlahuacÃ¡n de los membrillos,renta,Bodegas,https://casas.trovit.com.mx/renta-bodegas-ixtlahuacan-de-los-membrillos,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-trovit,El Salto,renta,Bodegas,https://casas.trovit.com.mx/renta-bodegas-el-salto,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-trovit,Tlajomulco de ZuÃ±iga,renta,Bodegas,https://casas.trovit.com.mx/renta-bodegas-tlajomulco-de-zuniga,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-trovit,Zapopan,venta,Bodegas,https://casas.trovit.com.mx/venta-bodegas-zapopan,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-trovit,Guadalajara,venta,Bodegas,https://casas.trovit.com.mx/venta-bodegas-guadalajara,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-trovit,San Pedro Tlaquepaque,venta,Bodegas,https://casas.trovit.com.mx/venta-bodegas-san-pedro-tlaquepaque,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-trovit,TonalÃ¡,venta,Bodegas,https://casas.trovit.com.mx/venta-bodegas-tonala,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-trovit,Zapotlanejo,venta,Bodegas,https://casas.trovit.com.mx/venta-bodegas-zapotlanejo,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-trovit,JuanacatlÃ¡n,venta,Bodegas,https://casas.trovit.com.mx/venta-bodegas-juanacatlan,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-trovit,IxtlahuacÃ¡n de los membrillos,venta,Bodegas,https://casas.trovit.com.mx/venta-bodegas-ixtlahuacan-de-los-membrillos,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-trovit,El Salto,venta,Bodegas,https://casas.trovit.com.mx/venta-bodegas-el-salto,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-trovit,Tlajomulco de ZuÃ±iga,venta,Bodegas,https://casas.trovit.com.mx/venta-bodegas-tlajomulco-de-zuniga,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-trovit,Zapopan,renta,locales,https://casas.trovit.com.mx/renta-locales-zapopan,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-trovit,Guadalajara,renta,locales,https://casas.trovit.com.mx/renta-locales-guadalajara,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-trovit,San Pedro Tlaquepaque,renta,locales,https://casas.trovit.com.mx/renta-locales-san-pedro-tlaquepaque,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-trovit,TonalÃ¡,renta,locales,https://casas.trovit.com.mx/renta-locales-tonala,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-trovit,Zapotlanejo,renta,locales,https://casas.trovit.com.mx/renta-locales-zapotlanejo,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-trovit,JuanacatlÃ¡n,renta,locales,https://casas.trovit.com.mx/renta-locales-juanacatlan,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-trovit,IxtlahuacÃ¡n de los membrillos,renta,locales,https://casas.trovit.com.mx/renta-locales-ixtlahuacan-de-los-membrillos,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-trovit,El Salto,renta,locales,https://casas.trovit.com.mx/renta-locales-el-salto,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-trovit,Tlajomulco de ZuÃ±iga,renta,locales,https://casas.trovit.com.mx/renta-locales-tlajomulco-de-zuniga,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-trovit,Zapopan,venta,locales,https://casas.trovit.com.mx/venta-locales-zapopan,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-trovit,Guadalajara,venta,locales,https://casas.trovit.com.mx/venta-locales-guadalajara,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-trovit,San Pedro Tlaquepaque,venta,locales,https://casas.trovit.com.mx/venta-locales-san-pedro-tlaquepaque,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-trovit,TonalÃ¡,venta,locales,https://casas.trovit.com.mx/venta-locales-tonala,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-trovit,Zapotlanejo,venta,locales,https://casas.trovit.com.mx/venta-locales-zapotlanejo,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-trovit,JuanacatlÃ¡n,venta,locales,https://casas.trovit.com.mx/venta-locales-juanacatlan,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-trovit,IxtlahuacÃ¡n de los membrillos,venta,locales,https://casas.trovit.com.mx/venta-locales-ixtlahuacan-de-los-membrillos,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-trovit,El Salto,venta,locales,https://casas.trovit.com.mx/venta-locales-el-salto,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-trovit,Tlajomulco de ZuÃ±iga,venta,locales,https://casas.trovit.com.mx/venta-locales-tlajomulco-de-zuniga,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-trovit,Zapopan,renta,Oficinas,https://casas.trovit.com.mx/renta-oficinas-zapopan,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-trovit,Guadalajara,renta,Oficinas,https://casas.trovit.com.mx/renta-oficinas-guadalajara,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-trovit,San Pedro Tlaquepaque,renta,Oficinas,https://casas.trovit.com.mx/renta-oficinas-san-pedro-tlaquepaque,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-trovit,TonalÃ¡,renta,Oficinas,https://casas.trovit.com.mx/renta-oficinas-tonala,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-trovit,Zapotlanejo,renta,Oficinas,https://casas.trovit.com.mx/renta-oficinas-zapotlanejo,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-trovit,JuanacatlÃ¡n,renta,Oficinas,https://casas.trovit.com.mx/renta-oficinas-juanacatlan,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-trovit,IxtlahuacÃ¡n de los membrillos,renta,Oficinas,https://casas.trovit.com.mx/renta-oficinas-ixtlahuacan-de-los-membrillos,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-trovit,El Salto,renta,Oficinas,https://casas.trovit.com.mx/renta-oficinas-el-salto,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-trovit,Tlajomulco de ZuÃ±iga,renta,Oficinas,https://casas.trovit.com.mx/renta-oficinas-tlajomulco-de-zuniga,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-trovit,Zapopan,venta,Oficinas,https://casas.trovit.com.mx/venta-oficinas-zapopan,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-trovit,Guadalajara,venta,Oficinas,https://casas.trovit.com.mx/venta-oficinas-guadalajara,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-trovit,San Pedro Tlaquepaque,venta,Oficinas,https://casas.trovit.com.mx/venta-oficinas-san-pedro-tlaquepaque,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-trovit,TonalÃ¡,venta,Oficinas,https://casas.trovit.com.mx/venta-oficinas-tonala,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-trovit,Zapotlanejo,venta,Oficinas,https://casas.trovit.com.mx/venta-oficinas-zapotlanejo,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-trovit,JuanacatlÃ¡n,venta,Oficinas,https://casas.trovit.com.mx/venta-oficinas-juanacatlan,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-trovit,IxtlahuacÃ¡n de los membrillos,venta,Oficinas,https://casas.trovit.com.mx/venta-oficinas-ixtlahuacan-de-los-membrillos,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-trovit,El Salto,venta,Oficinas,https://casas.trovit.com.mx/venta-oficinas-el-salto,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-trovit,Tlajomulco de ZuÃ±iga,venta,Oficinas,https://casas.trovit.com.mx/venta-oficinas-tlajomulco-de-zuniga,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-trovit,Zapopan,renta,Casas,https://casas.trovit.com.mx/renta-zapopan,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-trovit,Guadalajara,renta,Casas,https://casas.trovit.com.mx/renta-guadalajara,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-trovit,San Pedro Tlaquepaque,renta,Casas,https://casas.trovit.com.mx/renta-san-pedro-tlaquepaque,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-trovit,TonalÃ¡,renta,Casas,https://casas.trovit.com.mx/renta-tonala,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-trovit,Zapotlanejo,renta,Casas,https://casas.trovit.com.mx/renta-zapotlanejo,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-trovit,JuanacatlÃ¡n,renta,Casas,https://casas.trovit.com.mx/renta-juanacatlan,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-trovit,IxtlahuacÃ¡n de los membrillos,renta,Casas,https://casas.trovit.com.mx/renta-ixtlahuacan-de-los-membrillos,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-trovit,El Salto,renta,Casas,https://casas.trovit.com.mx/renta-el-salto,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-trovit,Tlajomulco de ZuÃ±iga,renta,Casas,https://casas.trovit.com.mx/renta-tlajomulco-de-zuniga,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-trovit,Zapopan,venta,Terrenos,https://casas.trovit.com.mx/venta-terrenos-zapopan,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-trovit,Guadalajara,venta,Terrenos,https://casas.trovit.com.mx/venta-terrenos-guadalajara,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-trovit,San Pedro Tlaquepaque,venta,Terrenos,https://casas.trovit.com.mx/venta-terrenos-san-pedro-tlaquepaque,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-trovit,TonalÃ¡,venta,Terrenos,https://casas.trovit.com.mx/venta-terrenos-tonala,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-trovit,Zapotlanejo,venta,Terrenos,https://casas.trovit.com.mx/venta-terrenos-zapotlanejo,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-trovit,JuanacatlÃ¡n,venta,Terrenos,https://casas.trovit.com.mx/venta-terrenos-juanacatlan,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-trovit,IxtlahuacÃ¡n de los membrillos,venta,Terrenos,https://casas.trovit.com.mx/venta-terrenos-ixtlahuacan-de-los-membrillos,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-trovit,El Salto,venta,Terrenos,https://casas.trovit.com.mx/venta-terrenos-el-salto,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-trovit,Tlajomulco de ZuÃ±iga,venta,Terrenos,https://casas.trovit.com.mx/venta-terrenos-tlajomulco-de-zuniga,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-trovit,Zapopan,venta,Casas,https://casas.trovit.com.mx/venta-zapopan,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-trovit,Guadalajara,venta,Casas,https://casas.trovit.com.mx/venta-guadalajara,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-trovit,San Pedro Tlaquepaque,venta,Casas,https://casas.trovit.com.mx/venta-san-pedro-tlaquepaque,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-trovit,TonalÃ¡,venta,Casas,https://casas.trovit.com.mx/venta-tonala,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-trovit,Zapotlanejo,venta,Casas,https://casas.trovit.com.mx/venta-zapotlanejo,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-trovit,JuanacatlÃ¡n,venta,Casas,https://casas.trovit.com.mx/venta-juanacatlan,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-trovit,IxtlahuacÃ¡n de los membrillos,venta,Casas,https://casas.trovit.com.mx/venta-ixtlahuacan-de-los-membrillos,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-trovit,El Salto,venta,Casas,https://casas.trovit.com.mx/venta-el-salto,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-trovit,Tlajomulco de ZuÃ±iga,venta,Casas,https://casas.trovit.com.mx/venta-tlajomulco-de-zuniga,,,,,,,,,,,,,,,,,,,,,,,,,,,,
+PaginaWeb,Ciudad,Operación,ProductoPaginaWeb,URL
+trovit,Zapopan,renta,Bodegas,https://casas.trovit.com.mx/renta-bodegas-zapopan
+trovit,Guadalajara,renta,Bodegas,https://casas.trovit.com.mx/renta-bodegas-guadalajara
+trovit,San Pedro Tlaquepaque,renta,Bodegas,https://casas.trovit.com.mx/renta-bodegas-san-pedro-tlaquepaque
+trovit,Tonalá,renta,Bodegas,https://casas.trovit.com.mx/renta-bodegas-tonala
+trovit,Zapotlanejo,renta,Bodegas,https://casas.trovit.com.mx/renta-bodegas-zapotlanejo
+trovit,Juanacatlán,renta,Bodegas,https://casas.trovit.com.mx/renta-bodegas-juanacatlan
+trovit,Ixtlahuacán de los membrillos,renta,Bodegas,https://casas.trovit.com.mx/renta-bodegas-ixtlahuacan-de-los-membrillos
+trovit,El Salto,renta,Bodegas,https://casas.trovit.com.mx/renta-bodegas-el-salto
+trovit,Tlajomulco de Zuñiga,renta,Bodegas,https://casas.trovit.com.mx/renta-bodegas-tlajomulco-de-zuniga
+trovit,Zapopan,venta,Bodegas,https://casas.trovit.com.mx/venta-bodegas-zapopan
+trovit,Guadalajara,venta,Bodegas,https://casas.trovit.com.mx/venta-bodegas-guadalajara
+trovit,San Pedro Tlaquepaque,venta,Bodegas,https://casas.trovit.com.mx/venta-bodegas-san-pedro-tlaquepaque
+trovit,Tonalá,venta,Bodegas,https://casas.trovit.com.mx/venta-bodegas-tonala
+trovit,Zapotlanejo,venta,Bodegas,https://casas.trovit.com.mx/venta-bodegas-zapotlanejo
+trovit,Juanacatlán,venta,Bodegas,https://casas.trovit.com.mx/venta-bodegas-juanacatlan
+trovit,Ixtlahuacán de los membrillos,venta,Bodegas,https://casas.trovit.com.mx/venta-bodegas-ixtlahuacan-de-los-membrillos
+trovit,El Salto,venta,Bodegas,https://casas.trovit.com.mx/venta-bodegas-el-salto
+trovit,Tlajomulco de Zuñiga,venta,Bodegas,https://casas.trovit.com.mx/venta-bodegas-tlajomulco-de-zuniga
+trovit,Zapopan,renta,locales,https://casas.trovit.com.mx/renta-locales-zapopan
+trovit,Guadalajara,renta,locales,https://casas.trovit.com.mx/renta-locales-guadalajara
+trovit,San Pedro Tlaquepaque,renta,locales,https://casas.trovit.com.mx/renta-locales-san-pedro-tlaquepaque
+trovit,Tonalá,renta,locales,https://casas.trovit.com.mx/renta-locales-tonala
+trovit,Zapotlanejo,renta,locales,https://casas.trovit.com.mx/renta-locales-zapotlanejo
+trovit,Juanacatlán,renta,locales,https://casas.trovit.com.mx/renta-locales-juanacatlan
+trovit,Ixtlahuacán de los membrillos,renta,locales,https://casas.trovit.com.mx/renta-locales-ixtlahuacan-de-los-membrillos
+trovit,El Salto,renta,locales,https://casas.trovit.com.mx/renta-locales-el-salto
+trovit,Tlajomulco de Zuñiga,renta,locales,https://casas.trovit.com.mx/renta-locales-tlajomulco-de-zuniga
+trovit,Zapopan,venta,locales,https://casas.trovit.com.mx/venta-locales-zapopan
+trovit,Guadalajara,venta,locales,https://casas.trovit.com.mx/venta-locales-guadalajara
+trovit,San Pedro Tlaquepaque,venta,locales,https://casas.trovit.com.mx/venta-locales-san-pedro-tlaquepaque
+trovit,Tonalá,venta,locales,https://casas.trovit.com.mx/venta-locales-tonala
+trovit,Zapotlanejo,venta,locales,https://casas.trovit.com.mx/venta-locales-zapotlanejo
+trovit,Juanacatlán,venta,locales,https://casas.trovit.com.mx/venta-locales-juanacatlan
+trovit,Ixtlahuacán de los membrillos,venta,locales,https://casas.trovit.com.mx/venta-locales-ixtlahuacan-de-los-membrillos
+trovit,El Salto,venta,locales,https://casas.trovit.com.mx/venta-locales-el-salto
+trovit,Tlajomulco de Zuñiga,venta,locales,https://casas.trovit.com.mx/venta-locales-tlajomulco-de-zuniga
+trovit,Zapopan,renta,Oficinas,https://casas.trovit.com.mx/renta-oficinas-zapopan
+trovit,Guadalajara,renta,Oficinas,https://casas.trovit.com.mx/renta-oficinas-guadalajara
+trovit,San Pedro Tlaquepaque,renta,Oficinas,https://casas.trovit.com.mx/renta-oficinas-san-pedro-tlaquepaque
+trovit,Tonalá,renta,Oficinas,https://casas.trovit.com.mx/renta-oficinas-tonala
+trovit,Zapotlanejo,renta,Oficinas,https://casas.trovit.com.mx/renta-oficinas-zapotlanejo
+trovit,Juanacatlán,renta,Oficinas,https://casas.trovit.com.mx/renta-oficinas-juanacatlan
+trovit,Ixtlahuacán de los membrillos,renta,Oficinas,https://casas.trovit.com.mx/renta-oficinas-ixtlahuacan-de-los-membrillos
+trovit,El Salto,renta,Oficinas,https://casas.trovit.com.mx/renta-oficinas-el-salto
+trovit,Tlajomulco de Zuñiga,renta,Oficinas,https://casas.trovit.com.mx/renta-oficinas-tlajomulco-de-zuniga
+trovit,Zapopan,venta,Oficinas,https://casas.trovit.com.mx/venta-oficinas-zapopan
+trovit,Guadalajara,venta,Oficinas,https://casas.trovit.com.mx/venta-oficinas-guadalajara
+trovit,San Pedro Tlaquepaque,venta,Oficinas,https://casas.trovit.com.mx/venta-oficinas-san-pedro-tlaquepaque
+trovit,Tonalá,venta,Oficinas,https://casas.trovit.com.mx/venta-oficinas-tonala
+trovit,Zapotlanejo,venta,Oficinas,https://casas.trovit.com.mx/venta-oficinas-zapotlanejo
+trovit,Juanacatlán,venta,Oficinas,https://casas.trovit.com.mx/venta-oficinas-juanacatlan
+trovit,Ixtlahuacán de los membrillos,venta,Oficinas,https://casas.trovit.com.mx/venta-oficinas-ixtlahuacan-de-los-membrillos
+trovit,El Salto,venta,Oficinas,https://casas.trovit.com.mx/venta-oficinas-el-salto
+trovit,Tlajomulco de Zuñiga,venta,Oficinas,https://casas.trovit.com.mx/venta-oficinas-tlajomulco-de-zuniga
+trovit,Zapopan,renta,Casas,https://casas.trovit.com.mx/renta-zapopan
+trovit,Guadalajara,renta,Casas,https://casas.trovit.com.mx/renta-guadalajara
+trovit,San Pedro Tlaquepaque,renta,Casas,https://casas.trovit.com.mx/renta-san-pedro-tlaquepaque
+trovit,Tonalá,renta,Casas,https://casas.trovit.com.mx/renta-tonala
+trovit,Zapotlanejo,renta,Casas,https://casas.trovit.com.mx/renta-zapotlanejo
+trovit,Juanacatlán,renta,Casas,https://casas.trovit.com.mx/renta-juanacatlan
+trovit,Ixtlahuacán de los membrillos,renta,Casas,https://casas.trovit.com.mx/renta-ixtlahuacan-de-los-membrillos
+trovit,El Salto,renta,Casas,https://casas.trovit.com.mx/renta-el-salto
+trovit,Tlajomulco de Zuñiga,renta,Casas,https://casas.trovit.com.mx/renta-tlajomulco-de-zuniga
+trovit,Zapopan,venta,Terrenos,https://casas.trovit.com.mx/venta-terrenos-zapopan
+trovit,Guadalajara,venta,Terrenos,https://casas.trovit.com.mx/venta-terrenos-guadalajara
+trovit,San Pedro Tlaquepaque,venta,Terrenos,https://casas.trovit.com.mx/venta-terrenos-san-pedro-tlaquepaque
+trovit,Tonalá,venta,Terrenos,https://casas.trovit.com.mx/venta-terrenos-tonala
+trovit,Zapotlanejo,venta,Terrenos,https://casas.trovit.com.mx/venta-terrenos-zapotlanejo
+trovit,Juanacatlán,venta,Terrenos,https://casas.trovit.com.mx/venta-terrenos-juanacatlan
+trovit,Ixtlahuacán de los membrillos,venta,Terrenos,https://casas.trovit.com.mx/venta-terrenos-ixtlahuacan-de-los-membrillos
+trovit,El Salto,venta,Terrenos,https://casas.trovit.com.mx/venta-terrenos-el-salto
+trovit,Tlajomulco de Zuñiga,venta,Terrenos,https://casas.trovit.com.mx/venta-terrenos-tlajomulco-de-zuniga
+trovit,Zapopan,venta,Casas,https://casas.trovit.com.mx/venta-zapopan
+trovit,Guadalajara,venta,Casas,https://casas.trovit.com.mx/venta-guadalajara
+trovit,San Pedro Tlaquepaque,venta,Casas,https://casas.trovit.com.mx/venta-san-pedro-tlaquepaque
+trovit,Tonalá,venta,Casas,https://casas.trovit.com.mx/venta-tonala
+trovit,Zapotlanejo,venta,Casas,https://casas.trovit.com.mx/venta-zapotlanejo
+trovit,Juanacatlán,venta,Casas,https://casas.trovit.com.mx/venta-juanacatlan
+trovit,Ixtlahuacán de los membrillos,venta,Casas,https://casas.trovit.com.mx/venta-ixtlahuacan-de-los-membrillos
+trovit,El Salto,venta,Casas,https://casas.trovit.com.mx/venta-el-salto
+trovit,Tlajomulco de Zuñiga,venta,Casas,https://casas.trovit.com.mx/venta-tlajomulco-de-zuniga


### PR DESCRIPTION
## Summary
- Clean CSV files under URLs/ to keep only PaginaWeb,Ciudad,Operación,ProductoPaginaWeb,URL columns
- Convert all files to UTF-8 and fix accented characters
- Remove embedded line breaks so each record is single row

## Testing
- `python - <<'PY'
import csv, os
for fname in sorted(os.listdir('URLs')):
    if fname.endswith('.csv'):
        with open(f'URLs/{fname}', encoding='utf-8') as f:
            reader = csv.DictReader(f)
            sum(1 for _ in reader)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68b41286cacc833189f768d6025ac952