### PR TITLE
Handle URL metadata dictionaries in scrapers and orchestrator

### DIFF
--- a/orchestrator/advanced_orchestrator.py
+++ b/orchestrator/advanced_orchestrator.py
@@ -186,12 +186,11 @@ class AdvancedOrchestrator:
             
             # Usar scrapers integrados
             website = scrap['website'].lower()
-            url = scrap['url']
             output_path = self.registry.get_output_path(
-                scrap['website'], 
-                scrap['state'], 
-                scrap['city'], 
-                scrap['operation'], 
+                scrap['website'],
+                scrap['state'],
+                scrap['city'],
+                scrap['operation'],
                 scrap['product']
             )
             
@@ -208,7 +207,7 @@ class AdvancedOrchestrator:
             # Ejecutar scraper en hilo separado
             scraper_thread = threading.Thread(
                 target=self.run_scraper_thread,
-                args=(website, url, output_path, scrap),
+                args=(scrap, output_path),
                 daemon=True
             )
             scraper_thread.start()
@@ -220,18 +219,19 @@ class AdvancedOrchestrator:
             self.registry.update_scrap_status(scrap['scrap_id'], 'failed')
             return None
     
-    def run_scraper_thread(self, website: str, url: str, output_path: str, scrap: Dict):
+    def run_scraper_thread(self, scrap: Dict, output_path: str):
         """Ejecutar scraper en hilo separado"""
         try:
-            self.logger.info(f"🚀 Ejecutando scraper para {website}: {url}")
-            
+            website = scrap['website'].lower()
+            self.logger.info(f"🚀 Ejecutando scraper para {website}: {scrap['url']}")
+
             # Ejecutar scraper correspondiente
             if website == 'inmuebles24':
-                result = run_inmuebles24(url, output_path, max_pages=None)
+                result = run_inmuebles24(scrap, output_path, max_pages=None)
             elif website == 'casas_y_terrenos':
-                result = run_casas_terrenos(url, output_path, max_pages=None)
+                result = run_casas_terrenos(scrap, output_path, max_pages=None)
             elif website == 'mitula':
-                result = run_mitula(url, output_path, max_pages=None)
+                result = run_mitula(scrap, output_path, max_pages=None)
             else:
                 self.logger.error(f"❌ Scraper no disponible para {website}")
                 result = {'success': False, 'error': 'Scraper not available'}

--- a/scrapers/cyt.py
+++ b/scrapers/cyt.py
@@ -15,7 +15,7 @@ import pickle
 import random
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple, Union
 import argparse
 
 # Selenium imports
@@ -26,15 +26,23 @@ from selenium.webdriver.support import expected_conditions as EC
 from selenium.common.exceptions import TimeoutException, NoSuchElementException
 
 # Utility function to load URLs from CSV
-def load_urls_from_csv(path: str) -> List[str]:
-    """Load target URLs from a CSV file returning the fifth column."""
-    urls: List[str] = []
+def load_urls_from_csv(path: str) -> List[Dict]:
+    """Load target URLs with metadata from a CSV file."""
+    urls: List[Dict] = []
     with open(path, newline='', encoding='utf-8') as csvfile:
-        reader = csv.reader(csvfile)
-        next(reader, None)  # skip header
+        reader = csv.DictReader(csvfile)
         for row in reader:
-            if len(row) > 4 and row[4]:
-                urls.append(row[4].strip())
+            url = row.get('URL') or row.get('Url') or row.get('url')
+            if url:
+                urls.append(
+                    {
+                        'website': row.get('PaginaWeb', '').strip(),
+                        'city': row.get('Ciudad', '').strip(),
+                        'operation': row.get('Operación', row.get('Operacion', '')).strip(),
+                        'product': row.get('ProductoPaginaWeb', '').strip(),
+                        'url': url.strip(),
+                    }
+                )
     return urls
 
 class CasasTerrenosProfessionalScraper:
@@ -725,9 +733,15 @@ def main():
     if args.gui:
         args.headless = False
 
-    urls: List[str]
+    urls: List[Dict]
     if args.url:
-        urls = [args.url]
+        urls = [{
+            'website': 'casas_y_terrenos',
+            'city': '',
+            'operation': args.operation,
+            'product': '',
+            'url': args.url
+        }]
     else:
         default_csv = Path(__file__).parent.parent / 'URLs' / 'cyt_urls.csv'
         csv_path = args.urls_file or default_csv
@@ -736,40 +750,60 @@ def main():
     success = True
     for target in urls:
         scraper = CasasTerrenosProfessionalScraper(
-            url=target,
+            url=target['url'],
             output_path=args.output,
             headless=args.headless,
             max_pages=args.pages,
             resume_from=args.resume,
-            operation_type=args.operation
+            operation_type=target.get('operation', args.operation)
         )
         result = scraper.run()
         success = success and result.get('success', False)
 
     sys.exit(0 if success else 1)
 
-def run_scraper(url: str = None, output_path: str = None,
-                max_pages: int = None, urls_file: str = None) -> List[Dict]:
+def run_scraper(url_data: Union[str, Dict] = None, output_path: str = None,
+                max_pages: int = None, urls_file: str = None) -> Union[Dict, List[Dict]]:
     """Interface function used by orchestrator for multiple URLs."""
-    if url:
-        urls = [url]
+    if url_data:
+        if isinstance(url_data, dict):
+            urls = [url_data]
+        else:
+            urls = [{
+                'website': 'casas_y_terrenos',
+                'city': '',
+                'operation': 'venta',
+                'product': '',
+                'url': url_data
+            }]
+        single = True
     else:
         default_csv = Path(__file__).parent.parent / 'URLs' / 'cyt_urls.csv'
         csv_path = urls_file or default_csv
         urls = load_urls_from_csv(csv_path)
+        single = False
 
     results: List[Dict] = []
     for target in urls:
         scraper = CasasTerrenosProfessionalScraper(
-            url=target,
+            url=target['url'],
             output_path=output_path,
             headless=True,
             max_pages=max_pages,
-            resume_from=1
+            resume_from=1,
+            operation_type=target.get('operation', 'venta')
         )
-        results.append(scraper.run())
+        result = scraper.run()
+        result.update({
+            'website': target.get('website'),
+            'city': target.get('city'),
+            'operation': target.get('operation'),
+            'product': target.get('product'),
+            'url': target.get('url'),
+        })
+        results.append(result)
 
-    return results
+    return results[0] if single else results
 
 if __name__ == "__main__":
     main()

--- a/scrapers/inm24.py
+++ b/scrapers/inm24.py
@@ -609,19 +609,40 @@ def main():
     # Retornar código de salida apropiado
     sys.exit(0 if results['success'] else 1)
 
-def run_scraper(url: str, output_path: str, max_pages: int = None) -> Dict:
-    """
-    Función de interfaz para usar desde el orquestador
-    """
+from typing import Union
+
+
+def run_scraper(url_data: Union[str, Dict], output_path: str, max_pages: int = None) -> Dict:
+    """Función de interfaz para usar desde el orquestador."""
+    if isinstance(url_data, dict):
+        target = url_data
+    else:
+        target = {
+            'website': 'inmuebles24',
+            'city': '',
+            'operation': 'venta',
+            'product': '',
+            'url': url_data
+        }
+
     scraper = Inmuebles24ProfessionalScraper(
-        url=url,
+        url=target['url'],
         output_path=output_path,
         headless=True,
         max_pages=max_pages,
-        resume_from=1
+        resume_from=1,
+        operation_type=target.get('operation', 'venta')
     )
-    
-    return scraper.run()
+
+    result = scraper.run()
+    result.update({
+        'website': target.get('website'),
+        'city': target.get('city'),
+        'operation': target.get('operation'),
+        'product': target.get('product'),
+        'url': target.get('url'),
+    })
+    return result
 
 if __name__ == "__main__":
     main()

--- a/scrapers/prop.py
+++ b/scrapers/prop.py
@@ -49,7 +49,7 @@ import logging
 import pickle
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple, Union
 import argparse
 
 # Selenium imports
@@ -60,15 +60,23 @@ from selenium.webdriver.support import expected_conditions as EC
 from selenium.common.exceptions import TimeoutException, NoSuchElementException
 
 # Utility function to load URLs from CSV
-def load_urls_from_csv(path: str) -> List[str]:
-    """Load target URLs from a CSV file returning the fifth column."""
-    urls: List[str] = []
+def load_urls_from_csv(path: str) -> List[Dict]:
+    """Load target URLs with metadata from a CSV file."""
+    urls: List[Dict] = []
     with open(path, newline='', encoding='utf-8') as csvfile:
-        reader = csv.reader(csvfile)
-        next(reader, None)
+        reader = csv.DictReader(csvfile)
         for row in reader:
-            if len(row) > 4 and row[4]:
-                urls.append(row[4].strip())
+            url = row.get('URL') or row.get('Url') or row.get('url')
+            if url:
+                urls.append(
+                    {
+                        'website': row.get('PaginaWeb', '').strip(),
+                        'city': row.get('Ciudad', '').strip(),
+                        'operation': row.get('Operación', row.get('Operacion', '')).strip(),
+                        'product': row.get('ProductoPaginaWeb', '').strip(),
+                        'url': url.strip(),
+                    }
+                )
     return urls
 
 class PropiedadesProfessionalScraper:
@@ -650,7 +658,13 @@ def main():
         args.headless = False
 
     if args.url:
-        urls = [args.url]
+        urls = [{
+            'website': 'propiedades',
+            'city': '',
+            'operation': args.operation,
+            'product': '',
+            'url': args.url
+        }]
     else:
         default_csv = Path(__file__).parent.parent / 'URLs' / 'prop_urls.csv'
         csv_path = args.urls_file or default_csv
@@ -662,24 +676,35 @@ def main():
             headless=args.headless,
             max_pages=args.pages,
             resume_from=args.resume,
-            operation_type=args.operation
+            operation_type=target.get('operation', args.operation)
         )
-        scraper.base_url = target
+        scraper.base_url = target['url']
         result = scraper.run()
         success = success and result.get('success', False)
 
     sys.exit(0 if success else 1)
 
 
-def run_scraper(url: str = None, max_pages: int = None,
-                urls_file: str = None) -> List[Dict]:
+def run_scraper(url_data: Union[str, Dict] = None, max_pages: int = None,
+                urls_file: str = None) -> Union[Dict, List[Dict]]:
     """Interface function for orchestrator to handle multiple URLs."""
-    if url:
-        urls = [url]
+    if url_data:
+        if isinstance(url_data, dict):
+            urls = [url_data]
+        else:
+            urls = [{
+                'website': 'propiedades',
+                'city': '',
+                'operation': 'venta',
+                'product': '',
+                'url': url_data
+            }]
+        single = True
     else:
         default_csv = Path(__file__).parent.parent / 'URLs' / 'prop_urls.csv'
         csv_path = urls_file or default_csv
         urls = load_urls_from_csv(csv_path)
+        single = False
 
     results: List[Dict] = []
     for target in urls:
@@ -687,12 +712,20 @@ def run_scraper(url: str = None, max_pages: int = None,
             headless=True,
             max_pages=max_pages,
             resume_from=1,
-            operation_type='venta'
+            operation_type=target.get('operation', 'venta')
         )
-        scraper.base_url = target
-        results.append(scraper.run())
+        scraper.base_url = target['url']
+        result = scraper.run()
+        result.update({
+            'website': target.get('website'),
+            'city': target.get('city'),
+            'operation': target.get('operation'),
+            'product': target.get('product'),
+            'url': target.get('url'),
+        })
+        results.append(result)
 
-    return results
+    return results[0] if single else results
 
 if __name__ == "__main__":
     main()

--- a/scrapers/tro.py
+++ b/scrapers/tro.py
@@ -15,7 +15,7 @@ import pickle
 import random
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple, Union
 import argparse
 
 # Selenium imports
@@ -26,15 +26,23 @@ from selenium.webdriver.support import expected_conditions as EC
 from selenium.common.exceptions import TimeoutException, NoSuchElementException
 
 # Utility function to load URLs from CSV
-def load_urls_from_csv(path: str) -> List[str]:
-    """Load target URLs from a CSV file returning the fifth column."""
-    urls: List[str] = []
+def load_urls_from_csv(path: str) -> List[Dict]:
+    """Load target URLs with metadata from a CSV file."""
+    urls: List[Dict] = []
     with open(path, newline='', encoding='utf-8') as csvfile:
-        reader = csv.reader(csvfile)
-        next(reader, None)  # skip header
+        reader = csv.DictReader(csvfile)
         for row in reader:
-            if len(row) > 4 and row[4]:
-                urls.append(row[4].strip())
+            url = row.get('URL') or row.get('Url') or row.get('url')
+            if url:
+                urls.append(
+                    {
+                        'website': row.get('PaginaWeb', '').strip(),
+                        'city': row.get('Ciudad', '').strip(),
+                        'operation': row.get('Operación', row.get('Operacion', '')).strip(),
+                        'product': row.get('ProductoPaginaWeb', '').strip(),
+                        'url': url.strip(),
+                    }
+                )
     return urls
 
 class TrovitProfessionalScraper:
@@ -750,7 +758,13 @@ def main():
         args.headless = False
 
     if args.url:
-        urls = [args.url]
+        urls = [{
+            'website': 'trovit',
+            'city': '',
+            'operation': args.operation,
+            'product': '',
+            'url': args.url
+        }]
     else:
         default_csv = Path(__file__).parent.parent / 'URLs' / 'tro_urls.csv'
         csv_path = args.urls_file or default_csv
@@ -759,41 +773,60 @@ def main():
     success = True
     for target in urls:
         scraper = TrovitProfessionalScraper(
-            url=target,
+            url=target['url'],
             output_path=args.output,
             headless=args.headless,
             max_pages=args.pages,
             resume_from=args.resume,
-            operation_type=args.operation
+            operation_type=target.get('operation', args.operation)
         )
         result = scraper.run()
         success = success and result.get('success', False)
 
     sys.exit(0 if success else 1)
 
-def run_scraper(url: str = None, output_path: str = None,
-                max_pages: int = None, urls_file: str = None) -> List[Dict]:
+def run_scraper(url_data: Union[str, Dict] = None, output_path: str = None,
+                max_pages: int = None, urls_file: str = None) -> Union[Dict, List[Dict]]:
     """Interface function used by orchestrator for multiple URLs."""
-    if url:
-        urls = [url]
+    if url_data:
+        if isinstance(url_data, dict):
+            urls = [url_data]
+        else:
+            urls = [{
+                'website': 'trovit',
+                'city': '',
+                'operation': 'venta',
+                'product': '',
+                'url': url_data
+            }]
+        single = True
     else:
         default_csv = Path(__file__).parent.parent / 'URLs' / 'tro_urls.csv'
         csv_path = urls_file or default_csv
         urls = load_urls_from_csv(csv_path)
+        single = False
 
     results: List[Dict] = []
     for target in urls:
         scraper = TrovitProfessionalScraper(
-            url=target,
+            url=target['url'],
             output_path=output_path,
             headless=True,
             max_pages=max_pages,
             resume_from=1,
-            operation_type='venta'
+            operation_type=target.get('operation', 'venta')
         )
-        results.append(scraper.run())
+        result = scraper.run()
+        result.update({
+            'website': target.get('website'),
+            'city': target.get('city'),
+            'operation': target.get('operation'),
+            'product': target.get('product'),
+            'url': target.get('url'),
+        })
+        results.append(result)
 
-    return results
+    return results[0] if single else results
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- Return full URL metadata from CSV loaders in scrapers
- Accept metadata dictionaries in `run_scraper` for each scraper and propagate fields to results
- Pass scrap dictionaries through Advanced Orchestrator to scrapers

## Testing
- `python -m py_compile scrapers/cyt.py scrapers/mit.py scrapers/tro.py scrapers/prop.py scrapers/inm24.py orchestrator/advanced_orchestrator.py`
- `pytest -q` *(fails: fixture 'website' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b418773d20833181984922cf124b6f