### PR TITLE
Integrate legacy docs into README and archive redundant files

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,18 @@ Sistema profesional de web scraping diseñado específicamente para el servidor 
 - **Monitoring**: Real-time logging + progress tracking
 - **Data Format**: CSV + JSON metadata
 
+### Componentes Principales
+
+| Componente | Función |
+|------------|---------|
+| `master_controller.py` | Control central SSH desde Windows |
+| `auto_deploy_manager.py` | Despliegue automatizado del sistema |
+| `advanced_orchestrator.py` | Orquestación concurrente de scrapers |
+| `enhanced_scraps_registry.py` | Registro y seguimiento de ejecuciones |
+| `checkpoint_recovery.py` | Recuperación tras interrupciones |
+| `gdrive_backup_manager.py` | Backup automático a Google Drive |
+| `system_setup.py` | Verificación completa del entorno |
+
 ## 📁 Estructura del Proyecto
 
 ```
@@ -125,6 +137,23 @@ data/{scraper_abrev}/{operation_abrev}/{mesAño}/{script}/
 - **renta**: Renta general
 - **venta-d**: Venta desarrollos (solo Inmuebles24)
 - **venta-r**: Venta remates (solo Inmuebles24)
+
+### Lista de URLs.csv
+
+Archivo central en `config/Lista de URLs.csv` con las columnas:
+
+```csv
+PaginaWeb,Estado,Ciudad,Operacion,ProductoPaginaWeb,URL
+Inmuebles24,Jalisco,Zapopan,venta,Departamentos,https://...
+Casas_y_terrenos,Jalisco,Guadalajara,renta,Casas,https://...
+mitula,Jalisco,Zapopan,venta,Casa,https://...
+```
+
+Notas de nomenclatura:
+
+- `Operacion` sin tilde.
+- Operaciones en minúsculas: `venta`, `renta`, `venta-d`, `venta-r`.
+- `venta-d` y `venta-r` aplican solo para Inmuebles24 (desarrollos y remates).
 
 ### Ejemplo de Ruta Actualizada
 ```

--- a/docs/historical/EXECUTIVE_DOCUMENTATION_HISTORICO.md
+++ b/docs/historical/EXECUTIVE_DOCUMENTATION_HISTORICO.md
@@ -1,4 +1,6 @@
-# PropertyScraper-Dell710 - Executive Documentation
+# [HISTÓRICO] PropertyScraper-Dell710 - Executive Documentation
+
+> Documento archivado. La información relevante se consolidó en `README.md`.
 
 ## 🎯 Sistema Completo de Web Scraping Profesional
 

--- a/docs/historical/README_SISTEMA_INTEGRADO_HISTORICO.md
+++ b/docs/historical/README_SISTEMA_INTEGRADO_HISTORICO.md
@@ -1,4 +1,6 @@
-# PropertyScraper Dell710 - Sistema Completamente Migrado
+# [HISTÓRICO] PropertyScraper Dell710 - Sistema Completamente Migrado
+
+> Documento archivado. La información relevante se consolidó en `README.md`.
 
 ## 🎯 Descripción General
 


### PR DESCRIPTION
## Summary
- Document key system components in README
- Explain Lista de URLs.csv structure in README
- Archive legacy documentation files

## Testing
- `pytest` *(fails: fixture 'website' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4c7794c20833195a41ce956e84d5f