### PR TITLE
Add Mitula, Propiedades, and Trovit scrapers to concurrent manager

### DIFF
--- a/orchestrator/concurrent_manager.py
+++ b/orchestrator/concurrent_manager.py
@@ -29,6 +29,9 @@ SCRAPER_MAP = {
     "lam": ("lam", "LamudiProfessionalScraper"),
     "lam_det": ("lam_det", "LamudiUnicoProfessionalScraper"),
     "cyt": ("cyt", "CasasTerrenosProfessionalScraper"),
+    "mit": ("mit", "MitulaProfessionalScraper"),
+    "prop": ("prop", "PropiedadesProfessionalScraper"),
+    "tro": ("tro", "TrovitProfessionalScraper"),
 }
 
 SCRAPER_CLASSES = {
@@ -231,6 +234,35 @@ class ConcurrentScraperManager:
                 scraper = scraper_cls(
                     headless=config.get('headless', True),
                     max_pages=config.get('max_pages'),
+                    operation_type=config.get('operation', 'venta')
+                )
+
+            elif site in ('mitula', 'mit'):
+                scraper_cls = SCRAPER_CLASSES['mit']
+                scraper = scraper_cls(
+                    url=config.get('url'),
+                    headless=config.get('headless', True),
+                    max_pages=config.get('max_pages'),
+                    resume_from=config.get('resume_from'),
+                    operation_type=config.get('operation', 'venta')
+                )
+
+            elif site in ('propiedades', 'prop'):
+                scraper_cls = SCRAPER_CLASSES['prop']
+                scraper = scraper_cls(
+                    headless=config.get('headless', True),
+                    max_pages=config.get('max_pages'),
+                    resume_from=config.get('resume_from'),
+                    operation_type=config.get('operation', 'venta')
+                )
+
+            elif site in ('trovit', 'tro'):
+                scraper_cls = SCRAPER_CLASSES['tro']
+                scraper = scraper_cls(
+                    url=config.get('url'),
+                    headless=config.get('headless', True),
+                    max_pages=config.get('max_pages'),
+                    resume_from=config.get('resume_from'),
                     operation_type=config.get('operation', 'venta')
                 )
 


### PR DESCRIPTION
## Summary
- include Mitula, Propiedades, and Trovit scrapers in `SCRAPER_MAP`
- handle `mit`, `prop`, and `tro` sites in `run_scraper_process`

## Testing
- `python -m pytest`
- `python - <<'PY'
from orchestrator.concurrent_manager import ConcurrentScraperManager

configs = [
    {
        'site': 'prop',
        'operation': 'venta',
        'headless': True,
        'max_pages': 1,
    },
    {
        'site': 'mit',
        'url': 'https://casas.mitula.mx/buscar/venta-departamentos-distrito+federal',
        'operation': 'venta',
        'headless': True,
        'max_pages': 1,
    },
    {
        'site': 'tro',
        'url': 'https://inmuebles.trovit.com.mx/index.php/cod.search_adwords_homes/type.1/what_d.piso%20distrito%20federal',
        'operation': 'venta',
        'headless': True,
        'max_pages': 1,
    },
]

manager = ConcurrentScraperManager(max_concurrent=1)
try:
    result = manager.run_batch_scraping(configs)
    print(result)
except Exception as e:
    print('Encountered error:', e)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68b4d4dda2d08331a5a591b59ce0e79d