### PR TITLE
Use per-site URL CSVs instead of central list

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,9 @@ PropertyScraper-Dell710/
 │   ├── gdrive_backup_manager.py
 │   ├── enhanced_scraps_registry.py
 │   └── url_utils.py
+├── URLs/                    # Archivos de URLs por sitio (cyt_urls.csv, mit_urls.csv, ...)
 ├── config/                   # Configuraciones del sistema
 │   ├── dell_t710_config.yaml
-│   ├── Lista de URLs.csv    # Configuración central de URLs con jerarquía
 │   └── ssh_config.json
 ├── monitoring/               # Sistema de monitoreo
 │   └── performance_monitor.py
@@ -138,15 +138,14 @@ data/{scraper_abrev}/{operation_abrev}/{mesAño}/{script}/
 - **venta-d**: Venta desarrollos (solo Inmuebles24)
 - **venta-r**: Venta remates (solo Inmuebles24)
 
-### Lista de URLs.csv
+### Archivos de URLs
 
-Archivo central en `config/Lista de URLs.csv` con las columnas:
+Los archivos CSV en `URLs/` son la única fuente de URLs del sistema y
+comparten las siguientes columnas:
 
 ```csv
-PaginaWeb,Estado,Ciudad,Operacion,ProductoPaginaWeb,URL
-Inmuebles24,Jalisco,Zapopan,venta,Departamentos,https://...
-Casas_y_terrenos,Jalisco,Guadalajara,renta,Casas,https://...
-mitula,Jalisco,Zapopan,venta,Casa,https://...
+PaginaWeb,Ciudad,Operacion,ProductoPaginaWeb,URL
+casas_y_terrenos,Guadalajara,Rentar,Edificios,https://...
 ```
 
 Notas de nomenclatura:
@@ -246,7 +245,7 @@ tail -f /home/scraper/PropertyScraper-Dell710/logs/progress_monitor.log
 - **8 Scrapers**: Todos funcionales con nueva nomenclatura
 - **SeleniumBase**: Configuración estandarizada y compatible
 - **Estructura de datos**: Optimizada con abreviaciones
-- **Lista de URLs.csv**: Única fuente de URLs del sistema (los CSV individuales en `URLs/` son legado).
+- **URLs/**: Carpeta con los CSV individuales; única fuente de URLs del sistema.
 
 ---
 

--- a/config/Lista de URLs.csv
+++ b/config/Lista de URLs.csv
@@ -1,2 +1,0 @@
-PaginaWeb,Estado,Ciudad,Operación,ProductoPaginaWeb,URL
-Inmuebles24,Jalisco,Zapopan,venta,Bodegas comerciales,https://www.inmuebles24.com/bodegas-comerciales-en-venta-en-zapopan.html

--- a/docs/historical/README_SISTEMA_INTEGRADO_HISTORICO.md
+++ b/docs/historical/README_SISTEMA_INTEGRADO_HISTORICO.md
@@ -4,7 +4,7 @@
 
 ## 🎯 Descripción General
 
-Sistema profesional de web scraping para bienes raíces optimizado para Dell PowerEdge T710, **completamente migrado con nomenclatura abreviada**, SeleniumBase unificado y más de 1000 URLs organizadas jerárquicamente en Lista de URLs.csv.
+Sistema profesional de web scraping para bienes raíces optimizado para Dell PowerEdge T710, **completamente migrado con nomenclatura abreviada**, SeleniumBase unificado y más de 1000 URLs organizadas en archivos CSV individuales dentro de ``URLs/``.
 
 ## 🆕 Migración Completa Realizada
 
@@ -19,17 +19,15 @@ Sistema profesional de web scraping para bienes raíces optimizado para Dell Pow
 - **Undetected Chrome**: UC mode para bypass automático
 
 ### ✅ Sistema CSV Dinámico Actualizado
-- **Lista de URLs.csv**: Base de datos maestra con jerarquía actualizada
-- **Estructura jerárquica**: PaginaWeb → Estado → Ciudad → Operacion → ProductoPaginaWeb → URL  
+- **URLs/**: Carpeta con archivos CSV por sitio
+- **Estructura unificada**: PaginaWeb → Ciudad → Operacion → ProductoPaginaWeb → URL
 - **Gestión automática**: Configuración centralizada sin URLs hardcodeadas
 
-## 📊 Estructura del CSV Actualizada
+## 📊 Estructura de los CSV
 
 ```csv
-PaginaWeb,Estado,Ciudad,Operacion,ProductoPaginaWeb,URL
-Inmuebles24,Jalisco,Zapopan,venta,Departamentos,https://...
-Casas_y_terrenos,Jalisco,Guadalajara,renta,Casas,https://...
-mitula,Jalisco,Zapopan,venta,Casa,https://...
+PaginaWeb,Ciudad,Operacion,ProductoPaginaWeb,URL
+casas_y_terrenos,Guadalajara,renta,Casas,https://...
 ```
 
 **Cambios en la nomenclatura:**
@@ -41,8 +39,8 @@ mitula,Jalisco,Zapopan,venta,Casa,https://...
 
 ```
 PropertyScraper-Dell710/
-├── config/
-│   └── Lista de URLs.csv                # 🔄 Base de datos con nomenclatura actualizada
+├── URLs/                               # CSVs por sitio
+├── config/                             
 ├── scrapers/                           # 🔄 Scrapers con nomenclatura abreviada
 │   ├── inm24.py                        # 🆕 inm24 general
 │   ├── inm24_det.py                    # 🆕 inm24 detallado
@@ -70,14 +68,14 @@ PropertyScraper-Dell710/
 
 ## 🚀 Instalación y Configuración Migrada
 
-### 1. Verificar Lista de URLs.csv
+### 1. Verificar archivos en URLs/
 ```bash
-# El archivo debe estar en PropertyScraper-Dell710/config/
-ls -la config/"Lista de URLs.csv"
+# Los archivos deben estar en PropertyScraper-Dell710/URLs/
+ls -la URLs/
 
 # Verificar estructura con nuevas columnas:
-# PaginaWeb, Estado, Ciudad, Operacion, ProductoPaginaWeb, URL
-head -5 config/"Lista de URLs.csv"
+# PaginaWeb, Ciudad, Operacion, ProductoPaginaWeb, URL
+head -5 URLs/cyt_urls.csv
 ```
 
 ### 2. Instalar SeleniumBase Unificado
@@ -189,21 +187,20 @@ registry.update_scrap_status(
 ## 🎯 Flujo de Trabajo del Orquestador
 
 ### 1. Fase de Planificación
-- Cargar URLs desde `Lista de URLs.csv`
+- Cargar URLs desde los archivos en `URLs/`
 - Generar scraps con IDs únicos
 - Establecer prioridades por website
 
 ### 2. Fase de Ejecución
 ```
 Para cada WEBSITE (máximo 4 simultáneos):
-  └── Para cada ESTADO:
-      └── Para cada CIUDAD:
-          └── Para cada OPERACIÓN:
-              └── Para cada PRODUCTO:
-                  └── Ejecutar scraper específico
-                  └── Guardar en estructura jerárquica
-                  └── Actualizar registry
-                  └── Programar backup a Google Drive
+  └── Para cada CIUDAD:
+      └── Para cada OPERACIÓN:
+          └── Para cada PRODUCTO:
+              └── Ejecutar scraper específico
+              └── Guardar en estructura jerárquica
+              └── Actualizar registry
+              └── Programar backup a Google Drive
 ```
 
 ### 3. Fase de Finalización
@@ -317,14 +314,14 @@ grep -r "chromium_arg.*no-sandbox" scrapers/
 # chromium_arg="--no-sandbox"
 ```
 
-### Error: Lista de URLs.csv formato incorrecto
+### Error: CSV en URLs/ formato incorrecto
 ```bash
 # Verificar columnas (sin tilde en Operacion)
-head -1 config/"Lista de URLs.csv"
-# Debe mostrar: PaginaWeb,Estado,Ciudad,Operacion,ProductoPaginaWeb,URL
+head -1 URLs/cyt_urls.csv
+# Debe mostrar: PaginaWeb,Ciudad,Operacion,ProductoPaginaWeb,URL
 
 # Verificar operaciones en minúsculas
-grep -i "Venta\|Renta" config/"Lista de URLs.csv"
+grep -i "Venta\|Renta" URLs/cyt_urls.csv
 # Cambiar a: venta, renta, venta-d, venta-r
 ```
 
@@ -390,14 +387,14 @@ for scraper in scrapers:
 1. **8 Scrapers migrados** - Nomenclatura abreviada implementada
 2. **SeleniumBase unificado** - Configuración estándar y compatible
 3. **Error 'no_sandbox' resuelto** - Migración a chromium_arg exitosa
-4. **Lista de URLs actualizada** - Nomenclatura y operaciones estandarizadas
+4. **Archivos de URLs actualizados** - Nomenclatura y operaciones estandarizadas
 5. **Estructura de datos optimizada** - Jerarquía simplificada
 6. **Orquestadores actualizados** - Referencias a nuevos nombres
 7. **Sistema de logs mejorado** - Nombres de archivo consistentes
 8. **Numeración automática** - Scripts numerados automáticamente
 
 ### Agregar Nuevas URLs al Sistema Migrado
-1. Editar `config/Lista de URLs.csv`
+1. Agregar o editar archivos en `URLs/`
 2. Usar nomenclatura estandarizada:
    - **PaginaWeb**: Nombre del sitio (case-sensitive)
    - **Operacion**: venta, renta, venta-d, venta-r (minúsculas)

--- a/orchestrator/advanced_orchestrator.py
+++ b/orchestrator/advanced_orchestrator.py
@@ -2,7 +2,7 @@
 """
 Advanced Orchestrator - PropertyScraper Dell710
 Orquestador avanzado con lógica de flujo de trabajo según especificaciones
-Adaptado para trabajar con Lista de URLs.csv
+Adaptado para trabajar con los archivos CSV individuales ubicados en ``URLs/``
 """
 
 import os
@@ -187,13 +187,7 @@ class AdvancedOrchestrator:
             # Usar scrapers integrados
             website = scrap['website'].lower()
             url = scrap['url']
-            output_path = self.registry.get_output_path(
-                scrap['website'], 
-                scrap['state'], 
-                scrap['city'], 
-                scrap['operation'], 
-                scrap['product']
-            )
+            output_path = self.registry.get_output_path(scrap)
             
             # Crear directorio de salida
             Path(output_path).parent.mkdir(parents=True, exist_ok=True)
@@ -277,7 +271,7 @@ class AdvancedOrchestrator:
                 python_path, script_path,
                 "--headless",
                 f"--url={scrap['url']}",
-                f"--output={self.registry.get_output_path(scrap['website'], scrap['state'], scrap['city'], scrap['operation'], scrap['product'])}",
+                f"--output={self.registry.get_output_path(scrap)}",
                 "--pages=50"  # Límite por defecto
             ]
             
@@ -405,8 +399,7 @@ class AdvancedOrchestrator:
                             'city': row.get('Ciudad', '').strip(),
                             'operation': (row.get('Operación') or row.get('Operacion') or row.get('Operacin') or '').strip().lower(),
                             'product': row.get('ProductoPaginaWeb', '').strip(),
-                            'url': url,
-                            'state': row.get('Estado', '').strip() or 'desconocido'
+                            'url': url
                         }
                         tasks_by_site.setdefault(task['website'], []).append(task)
             except Exception as e:

--- a/scrapers/cyt.py
+++ b/scrapers/cyt.py
@@ -2,7 +2,7 @@
 """
 Casas y Terrenos Professional Scraper - PropertyScraper Dell710
 Scraper profesional optimizado para Dell T710 con capacidades de resilencia
-Adaptado para trabajar con Lista de URLs.csv
+Adaptado para trabajar con ``URLs/cyt_urls.csv``
 """
 
 import os

--- a/scrapers/inm24.py
+++ b/scrapers/inm24.py
@@ -2,7 +2,7 @@
 """
 Inmuebles24 Professional Scraper - PropertyScraper Dell710
 Scraper profesional optimizado para Dell T710 con capacidades de resilencia
-Adaptado para trabajar con Lista de URLs.csv
+Adaptado para trabajar con ``URLs/inm24_urls.csv``
 """
 
 import os

--- a/scrapers/mit.py
+++ b/scrapers/mit.py
@@ -2,7 +2,7 @@
 """
 Mitula Professional Scraper - PropertyScraper Dell710
 Scraper profesional optimizado para Dell T710 con capacidades de resilencia
-Adaptado para trabajar con Lista de URLs.csv
+Adaptado para trabajar con ``URLs/mit_urls.csv``
 """
 
 import os

--- a/scrapers/tro.py
+++ b/scrapers/tro.py
@@ -2,7 +2,7 @@
 """
 Trovit Professional Scraper - PropertyScraper Dell710
 Scraper profesional optimizado para Dell T710 con capacidades de resilencia
-Adaptado para trabajar con Lista de URLs.csv
+Adaptado para trabajar con ``URLs/tro_urls.csv``
 """
 
 import os


### PR DESCRIPTION
## Summary
- Remove `config/Lista de URLs.csv` and iterate over all CSV files in `URLs/`
- Update registry, orchestrator, and setup to load URLs from the `URLs/` directory
- Refresh scraper docstrings and documentation to point at the per-site URL files

## Testing
- `pytest -q`
- `python -m py_compile orchestrator/advanced_orchestrator.py setup_inicial.py utils/enhanced_scraps_registry.py scrapers/cyt.py scrapers/inm24.py scrapers/mit.py scrapers/tro.py`


------
https://chatgpt.com/codex/tasks/task_e_68b4e598d4b88331981f83994b0b638d