### PR TITLE
refactor: centralize path and run logic

### DIFF
--- a/scrapers/lam_det.py
+++ b/scrapers/lam_det.py
@@ -23,6 +23,7 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.common.exceptions import TimeoutException, NoSuchElementException
+from utils.path_builder import build_path
 
 class LamudiUnicoProfessionalScraper:
     """
@@ -68,54 +69,17 @@ class LamudiUnicoProfessionalScraper:
     def setup_paths(self):
         """Configurar estructura de paths del proyecto"""
         self.project_root = Path(__file__).parent.parent
-        
-        # Configuración de operaciones con abreviaciones
-        operation_folders = {
-            'venta': 'ven',
-            'renta': 'ren'
-        }
-        operation_folder = operation_folders.get(self.operation_type, 'ven')
-        
-        # Obtener fecha actual en formato abreviado
-        now = datetime.now()
-        month_abbrev = self.get_month_abbreviation(now.month)
-        year_short = str(now.year)[2:]  # Últimos 2 dígitos del año
-        script_number = self.get_script_number(month_abbrev, year_short)
-        
-        # Nueva estructura: data/lam/{operation}/{mesAño}/{script}/
-        self.data_dir = self.project_root / 'data' / 'lam' / operation_folder / f"{month_abbrev}{year_short}" / str(script_number)
         self.logs_dir = self.project_root / 'logs'
-        self.checkpoint_dir = self.project_root / 'logs' / 'checkpoints'
-        
-        # Crear directorios si no existen
-        for directory in [self.data_dir, self.logs_dir, self.checkpoint_dir]:
+        self.checkpoint_dir = self.logs_dir / 'checkpoints'
+
+        path_info = build_path('Lam', 'Ciudad', self.operation_type, 'Detalle')
+        self.month_year = path_info.month_year
+        self.run_number = int(path_info.run_number)
+        self.data_dir = path_info.directory
+
+        for directory in [self.logs_dir, self.checkpoint_dir]:
             directory.mkdir(parents=True, exist_ok=True)
     
-    def get_month_abbreviation(self, month_num):
-        """Obtener abreviatura de 3 letras del mes"""
-        month_abbrevs = {
-            1: 'ene', 2: 'feb', 3: 'mar', 4: 'abr', 5: 'may', 6: 'jun',
-            7: 'jul', 8: 'ago', 9: 'sep', 10: 'oct', 11: 'nov', 12: 'dic'
-        }
-        return month_abbrevs.get(month_num, 'unk')
-    
-    def get_script_number(self, month_abbrev, year_short):
-        """Detectar automáticamente el número de script basado en carpetas existentes"""
-        # Construir la ruta base para este mes/año
-        operation_folders = {'venta': 'ven', 'renta': 'ren'}
-        operation_folder = operation_folders.get(self.operation_type, 'ven')
-        base_path = self.project_root / 'data' / 'lam' / operation_folder / f"{month_abbrev}{year_short}"
-        
-        if not base_path.exists():
-            return 1
-        
-        # Buscar carpetas numéricas existentes
-        existing_scripts = []
-        for item in base_path.iterdir():
-            if item.is_dir() and item.name.isdigit():
-                existing_scripts.append(int(item.name))
-        
-        return max(existing_scripts) + 1 if existing_scripts else 1
     
     def setup_logging(self):
         """Configurar sistema de logging profesional"""
@@ -571,15 +535,13 @@ class LamudiUnicoProfessionalScraper:
 
         # Generar timestamp para archivos
         timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
-        
-        # Obtener fecha actual en formato abreviado para nombre de archivo
-        now = datetime.now()
-        month_abbrev = self.get_month_abbreviation(now.month)
-        year_short = str(now.year)[2:]
-        script_number = str(self.get_script_number(month_abbrev, year_short) - 1)  # -1 porque ya se creó la carpeta
-        
+
+        run_str = f"{self.run_number:02d}"
+        month_abbrev = self.month_year[:3]
+        year_short = self.month_year[-2:]
+
         # Archivo CSV de detalles con nueva nomenclatura
-        csv_filename = f"lam_det_{month_abbrev}{year_short}_{script_number}.csv"
+        csv_filename = f"lam_det_{month_abbrev}{year_short}_{run_str}.csv"
         csv_path = self.data_dir / csv_filename
         
         # Guardar CSV

--- a/scrapers/mit.py
+++ b/scrapers/mit.py
@@ -23,6 +23,7 @@ from utils.url_utils import (
     load_urls_from_csv,
     load_urls_for_site,
 )
+from utils.path_builder import build_path
 
 # Selenium imports
 from seleniumbase import SB
@@ -100,54 +101,16 @@ class MitulaProfessionalScraper:
     def setup_paths(self):
         """Configurar estructura de paths del proyecto"""
         self.project_root = Path(__file__).parent.parent
-        
-        # Configuración de operaciones con abreviaciones
-        operation_folders = {
-            'venta': 'ven',
-            'renta': 'ren'
-        }
-        operation_folder = operation_folders.get(self.operation_type, 'ven')
-        
-        # Obtener fecha actual en formato abreviado
-        now = datetime.now()
-        month_abbrev = self.get_month_abbreviation(now.month)
-        year_short = str(now.year)[2:]  # Últimos 2 dígitos del año
-        script_number = self.get_script_number(month_abbrev, year_short)
-        
-        # Nueva estructura: data/mit/{operation}/{mesAño}/{script}/
-        self.data_dir = self.project_root / 'data' / 'mit' / operation_folder / f"{month_abbrev}{year_short}" / str(script_number)
         self.logs_dir = self.project_root / 'logs'
-        self.checkpoint_dir = self.project_root / 'logs' / 'checkpoints'
-        
-        # Crear directorios si no existen
-        for directory in [self.data_dir, self.logs_dir, self.checkpoint_dir]:
+        self.checkpoint_dir = self.logs_dir / 'checkpoints'
+
+        path_info = build_path('Mit', 'Ciudad', self.operation_type, 'Producto')
+        self.month_year = path_info.month_year
+        self.run_number = int(path_info.run_number)
+        self.data_dir = path_info.directory
+
+        for directory in [self.logs_dir, self.checkpoint_dir]:
             directory.mkdir(parents=True, exist_ok=True)
-    
-    def get_month_abbreviation(self, month_num):
-        """Obtener abreviatura de 3 letras del mes"""
-        month_abbrevs = {
-            1: 'ene', 2: 'feb', 3: 'mar', 4: 'abr', 5: 'may', 6: 'jun',
-            7: 'jul', 8: 'ago', 9: 'sep', 10: 'oct', 11: 'nov', 12: 'dic'
-        }
-        return month_abbrevs.get(month_num, 'unk')
-    
-    def get_script_number(self, month_abbrev, year_short):
-        """Detectar automáticamente el número de script basado en carpetas existentes"""
-        # Construir la ruta base para este mes/año
-        operation_folders = {'venta': 'ven', 'renta': 'ren'}
-        operation_folder = operation_folders.get(self.operation_type, 'ven')
-        base_path = self.project_root / 'data' / 'mit' / operation_folder / f"{month_abbrev}{year_short}"
-        
-        if not base_path.exists():
-            return 1
-        
-        # Buscar carpetas numéricas existentes
-        existing_scripts = []
-        for item in base_path.iterdir():
-            if item.is_dir() and item.name.isdigit():
-                existing_scripts.append(int(item.name))
-        
-        return max(existing_scripts) + 1 if existing_scripts else 1
     
     def setup_logging(self):
         """Configurar sistema de logging profesional"""
@@ -622,17 +585,15 @@ class MitulaProfessionalScraper:
         # Generar timestamp para archivos
         timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
         
-        # Obtener fecha actual en formato abreviado para nombre de archivo
-        now = datetime.now()
-        month_abbrev = self.get_month_abbreviation(now.month)
-        year_short = str(now.year)[2:]
-        script_number = str(self.get_script_number(month_abbrev, year_short) - 1)  # -1 porque ya se creó la carpeta
-        
+        run_str = f"{self.run_number:02d}"
+        month_abbrev = self.month_year[:3]
+        year_short = self.month_year[-2:]
+
         # Usar la ruta proporcionada o crear una con nueva nomenclatura
         if self.output_path:
             csv_path = Path(self.output_path)
         else:
-            csv_filename = f"mit_{month_abbrev}{year_short}_{script_number}.csv"
+            csv_filename = f"mit_{month_abbrev}{year_short}_{run_str}.csv"
             csv_path = self.data_dir / csv_filename
         
         # Crear directorio si no existe

--- a/scrapers/tro.py
+++ b/scrapers/tro.py
@@ -23,6 +23,7 @@ from utils.url_utils import (
     load_urls_from_csv,
     load_urls_for_site,
 )
+from utils.path_builder import build_path
 
 # Selenium imports
 from seleniumbase import SB
@@ -100,54 +101,16 @@ class TrovitProfessionalScraper:
     def setup_paths(self):
         """Configurar estructura de paths del proyecto"""
         self.project_root = Path(__file__).parent.parent
-        
-        # Configuración de operaciones con abreviaciones
-        operation_folders = {
-            'venta': 'ven',
-            'renta': 'ren'
-        }
-        operation_folder = operation_folders.get(self.operation_type, 'ven')
-        
-        # Obtener fecha actual en formato abreviado
-        now = datetime.now()
-        month_abbrev = self.get_month_abbreviation(now.month)
-        year_short = str(now.year)[2:]  # Últimos 2 dígitos del año
-        script_number = self.get_script_number(month_abbrev, year_short)
-        
-        # Nueva estructura: data/mit/{operation}/{mesAño}/{script}/
-        self.data_dir = self.project_root / 'data' / 'mit' / operation_folder / f"{month_abbrev}{year_short}" / str(script_number)
         self.logs_dir = self.project_root / 'logs'
-        self.checkpoint_dir = self.project_root / 'logs' / 'checkpoints'
-        
-        # Crear directorios si no existen
-        for directory in [self.data_dir, self.logs_dir, self.checkpoint_dir]:
+        self.checkpoint_dir = self.logs_dir / 'checkpoints'
+
+        path_info = build_path('Tro', 'Ciudad', self.operation_type, 'Producto')
+        self.month_year = path_info.month_year
+        self.run_number = int(path_info.run_number)
+        self.data_dir = path_info.directory
+
+        for directory in [self.logs_dir, self.checkpoint_dir]:
             directory.mkdir(parents=True, exist_ok=True)
-    
-    def get_month_abbreviation(self, month_num):
-        """Obtener abreviatura de 3 letras del mes"""
-        month_abbrevs = {
-            1: 'ene', 2: 'feb', 3: 'mar', 4: 'abr', 5: 'may', 6: 'jun',
-            7: 'jul', 8: 'ago', 9: 'sep', 10: 'oct', 11: 'nov', 12: 'dic'
-        }
-        return month_abbrevs.get(month_num, 'unk')
-    
-    def get_script_number(self, month_abbrev, year_short):
-        """Detectar automáticamente el número de script basado en carpetas existentes"""
-        # Construir la ruta base para este mes/año
-        operation_folders = {'venta': 'ven', 'renta': 'ren'}
-        operation_folder = operation_folders.get(self.operation_type, 'ven')
-        base_path = self.project_root / 'data' / 'mit' / operation_folder / f"{month_abbrev}{year_short}"
-        
-        if not base_path.exists():
-            return 1
-        
-        # Buscar carpetas numéricas existentes
-        existing_scripts = []
-        for item in base_path.iterdir():
-            if item.is_dir() and item.name.isdigit():
-                existing_scripts.append(int(item.name))
-        
-        return max(existing_scripts) + 1 if existing_scripts else 1
     
     def setup_logging(self):
         """Configurar sistema de logging profesional"""
@@ -635,17 +598,15 @@ class TrovitProfessionalScraper:
         # Generar timestamp para archivos
         timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
         
-        # Obtener fecha actual en formato abreviado para nombre de archivo
-        now = datetime.now()
-        month_abbrev = self.get_month_abbreviation(now.month)
-        year_short = str(now.year)[2:]
-        script_number = str(self.get_script_number(month_abbrev, year_short) - 1)  # -1 porque ya se creó la carpeta
-        
+        run_str = f"{self.run_number:02d}"
+        month_abbrev = self.month_year[:3]
+        year_short = self.month_year[-2:]
+
         # Usar la ruta proporcionada o crear una con nueva nomenclatura
         if self.output_path:
             csv_path = Path(self.output_path)
         else:
-            csv_filename = f"tro_{month_abbrev}{year_short}_{script_number}.csv"
+            csv_filename = f"tro_{month_abbrev}{year_short}_{run_str}.csv"
             csv_path = self.data_dir / csv_filename
         
         # Crear directorio si no existe

--- a/utils/path_builder.py
+++ b/utils/path_builder.py
@@ -1,0 +1,58 @@
+"""Utilities for constructing data paths with standardized month and run logic."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+import calendar
+from pathlib import Path
+
+
+@dataclass
+class PathInfo:
+    """Container for paths and identifiers used when saving scraper output."""
+    directory: Path
+    file_name: str
+    month_year: str
+    run_number: str
+
+
+def build_path(pagina_web: str, ciudad: str, operacion: str, producto: str) -> PathInfo:
+    """Build the directory and file name for a scraping run.
+
+    Args:
+        pagina_web: Website identifier (e.g. ``"Cyt"``).
+        ciudad: City name.
+        operacion: Type of operation (e.g. ``"venta"``).
+        producto: Product type for the website.
+
+    Returns:
+        PathInfo containing the final directory, default file name, month-year
+        string and run number.
+    """
+    project_root = Path(__file__).resolve().parent.parent
+
+    now = datetime.now()
+    month_abbr = calendar.month_abbr[now.month]
+    year_short = str(now.year)[-2:]
+    month_year = f"{month_abbr}{year_short}"
+
+    base_dir = (
+        project_root
+        / "data"
+        / pagina_web.capitalize()
+        / ciudad.capitalize()
+        / operacion.capitalize()
+        / producto.capitalize()
+        / month_year
+    )
+
+    run = 1
+    while (base_dir / f"{run:02d}").exists():
+        run += 1
+    run_str = f"{run:02d}"
+
+    final_dir = base_dir / run_str
+    final_dir.mkdir(parents=True, exist_ok=True)
+
+    file_name = f"{pagina_web.lower()}_{month_year}_{run_str}.csv"
+    return PathInfo(final_dir, file_name, month_year, run_str)


### PR DESCRIPTION
## Summary
- add reusable `build_path` helper for month/year and run-number folders
- update all scrapers to use shared helper
- drop repeated month/run utilities across scrapers

## Testing
- `python -m py_compile utils/path_builder.py scrapers/cyt.py scrapers/lam.py scrapers/lam_det.py scrapers/mit.py scrapers/prop.py scrapers/tro.py scrapers/inm24.py scrapers/inm24_det.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b51a98a26883319b723620d348b219