### PR TITLE
Use 'operacion' field for scrap metadata and backup paths

### DIFF
--- a/orchestrator/advanced_orchestrator.py
+++ b/orchestrator/advanced_orchestrator.py
@@ -454,11 +454,18 @@ class AdvancedOrchestrator:
         """Construir la ruta de salida para una tarea"""
         safe_city = task['ciudad'].lower().replace(' ', '_')
         safe_product = task['producto'].lower().replace(' ', '_')
-        operation = task['operacion']
+        operacion = task['operacion']
         website = task['website']
         timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
 
-        output_dir = Path(__file__).parent.parent / 'data' / 'batch_csv' / website / safe_city / operation
+        output_dir = (
+            Path(__file__).parent.parent
+            / 'data'
+            / 'batch_csv'
+            / website
+            / safe_city
+            / operacion
+        )
         output_dir.mkdir(parents=True, exist_ok=True)
         return str(output_dir / f"{safe_product}_{timestamp}.csv")
 

--- a/utils/enhanced_scraps_registry.py
+++ b/utils/enhanced_scraps_registry.py
@@ -510,7 +510,7 @@ class EnhancedScrapsRegistry:
         """Obtener la ruta de salida para un scrap específico"""
         website = scrap_data.get('website', '').lower()
         ciudad = scrap_data.get('ciudad', scrap_data.get('city', '')).lower().replace(' ', '_')
-        operacion = scrap_data.get('operacion', scrap_data.get('operation', '')).lower()
+        operacion = scrap_data.get('operacion', '').lower()
         producto = scrap_data.get('producto', scrap_data.get('product', '')).lower().replace(' ', '_')
 
         # Crear estructura de carpetas organizada
@@ -527,7 +527,7 @@ class EnhancedScrapsRegistry:
         """Obtener la ruta de backup en Google Drive"""
         website = scrap_data.get('website', '')
         ciudad = scrap_data.get('ciudad', scrap_data.get('city', '')).replace(' ', '_')
-        operacion = scrap_data.get('operacion', scrap_data.get('operation', ''))
+        operacion = scrap_data.get('operacion', '').replace(' ', '_')
 
         # Estructura para Google Drive
         return f"PropertyScraper/{website}/{ciudad}/{operacion}/"


### PR DESCRIPTION
## Summary
- ensure orchestrator output paths use `operacion` field
- build registry output and backup paths from `operacion`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b8f6cf36148331b426614f386258ed