### PR TITLE
Sort website scraps using CSV row order

### DIFF
--- a/orchestrator/advanced_orchestrator.py
+++ b/orchestrator/advanced_orchestrator.py
@@ -184,7 +184,7 @@ class AdvancedOrchestrator:
     def get_scraps_for_website(self, website: str) -> List[Dict]:
         """
         Obtener todos los scraps pendientes para una página web específica
-        Ordenados por: operación -> producto
+        Ordenados por: posición en el CSV (csv_row)
         """
         all_scraps = self.registry.load_urls_from_csv()
         
@@ -196,8 +196,8 @@ class AdvancedOrchestrator:
                   datetime.now() >= datetime.fromisoformat(scrap['next_run'])))):
                 website_scraps.append(scrap)
         
-        # Ordenar por operación y producto
-        website_scraps.sort(key=lambda x: (x['operacion'], x['producto']))
+        # Ordenar según la fila en el CSV para preservar el orden definido
+        website_scraps.sort(key=lambda x: x['csv_row'])
         
         return website_scraps
     

--- a/tests/test_scrap_order.py
+++ b/tests/test_scrap_order.py
@@ -1,0 +1,59 @@
+import csv
+import sys
+import logging
+from pathlib import Path
+
+# Asegurar que el proyecto esté en el PYTHONPATH
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from orchestrator import advanced_orchestrator as ao
+from utils.enhanced_scraps_registry import EnhancedScrapsRegistry
+
+
+class DummyOrchestrator(ao.AdvancedOrchestrator):
+    def __init__(self):
+        # Inicialización mínima para pruebas
+        self.registry = EnhancedScrapsRegistry()
+        self.logger = logging.getLogger("DummyOrchestrator")
+
+
+def _create_csv(csv_path):
+    header = [
+        "PaginaWeb",
+        "Ciudad",
+        "Operacion",
+        "ProductoPaginaWeb",
+        "URL",
+        "Status",
+        "LastRun",
+        "NextRun",
+        "ScrapOfMonth",
+        "Records",
+    ]
+    rows = [
+        ("TestSite", "City", "B", "ProdY", "http://a.com", "pending", "", "", "", ""),
+        ("TestSite", "City", "A", "ProdZ", "http://b.com", "pending", "", "", "", ""),
+        ("TestSite", "City", "C", "ProdX", "http://c.com", "pending", "", "", "", ""),
+    ]
+    with open(csv_path, "w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(header)
+        writer.writerows(rows)
+
+
+def test_get_scraps_in_csv_order(tmp_path):
+    csv_file = tmp_path / "test_urls.csv"
+    _create_csv(csv_file)
+
+    orchestrator = DummyOrchestrator()
+    orchestrator.registry.csv_urls_dir = tmp_path
+
+    scraps = orchestrator.get_scraps_for_website("TestSite")
+
+    assert [s["csv_row"] for s in scraps] == [1, 2, 3]
+    assert [s["url"] for s in scraps] == [
+        "http://a.com",
+        "http://b.com",
+        "http://c.com",
+    ]
+    assert [s["operacion"] for s in scraps] == ["B", "A", "C"]

--- a/utils/enhanced_scraps_registry.py
+++ b/utils/enhanced_scraps_registry.py
@@ -156,7 +156,8 @@ class EnhancedScrapsRegistry:
             self.logger.warning(f"Directorio de URLs no encontrado: {self.csv_urls_dir}")
             return urls_list
 
-        csv_files = list(self.csv_urls_dir.glob('*.csv'))
+        # Procesar los archivos en orden alfabético para asegurar consistencia
+        csv_files = sorted(self.csv_urls_dir.glob('*.csv'))
         if not csv_files:
             self.logger.warning(f"No se encontraron archivos CSV en {self.csv_urls_dir}")
             return urls_list
@@ -171,7 +172,7 @@ class EnhancedScrapsRegistry:
                         row for row in f if not row.lstrip().startswith('#')
                     )
 
-                    for idx, row in enumerate(reader, 1):
+                    for row_num, row in enumerate(reader, start=1):
                         pagina_web = row.get('PaginaWeb', '').strip()
                         ciudad = row.get('Ciudad', '').strip()
                         operacion = row.get('Operacion', row.get('Operación', '')).strip()
@@ -200,7 +201,8 @@ class EnhancedScrapsRegistry:
                                 'prioridad': self.get_website_priority(pagina_web),
                                 'intervalo_dias': self.get_interval_days(pagina_web),
                                 'activo': True,
-                                'csv_row': idx,
+                                # Guardar el número de fila para respetar el orden del CSV
+                                'csv_row': row_num,
                                 'csv_file': csv_file.name,
                                 'status': row.get('Status', ''),
                                 'last_run': row.get('LastRun', ''),


### PR DESCRIPTION
## Summary
- Preserve CSV-defined order by sorting scraps by `csv_row`
- Ensure `EnhancedScrapsRegistry` tracks row numbers sequentially
- Add test verifying orchestrator processes URLs in CSV sequence

## Testing
- `pytest tests/test_scrap_order.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b9007da2288331a1b04c5a6f4f4ebe