### PR TITLE
Add run_scraper helpers and integrate detail scrapers

### DIFF
--- a/scrapers/inm24_det.py
+++ b/scrapers/inm24_det.py
@@ -1016,6 +1016,30 @@ class Inmuebles24UnicoProfessionalScraper:
                 'successful_extractions': self.successful_extractions
             }
 
+def run_scraper(urls_file: str, output_path: str | None = None,
+                max_properties: int = None) -> Dict:
+    """Interface function for orchestrator usage."""
+
+    operation_type = 'venta'
+    if urls_file:
+        name = Path(urls_file).name.upper()
+        if '_REN_' in name:
+            operation_type = 'renta'
+        elif '_VND_' in name:
+            operation_type = 'venta-d'
+        elif '_VNR_' in name:
+            operation_type = 'venta-r'
+
+    scraper = Inmuebles24UnicoProfessionalScraper(
+        urls_file=urls_file,
+        headless=True,
+        max_properties=max_properties,
+        resume_from=0,
+        operation_type=operation_type,
+    )
+
+    return scraper.run()
+
 def main():
     """Función principal con argumentos de línea de comandos"""
     parser = argparse.ArgumentParser(description='Inmuebles24 Unico Professional Scraper')

--- a/scrapers/lam.py
+++ b/scrapers/lam.py
@@ -660,6 +660,44 @@ class LamudiProfessionalScraper:
                 'properties_found': self.properties_found
             }
 
+def run_scraper(url: str, output_path: str, max_pages: int = None) -> Dict:
+    """Interface function for the orchestrator.
+
+    Args:
+        url: Listing URL to scrape.
+        output_path: Path where results should be stored. Used to infer
+            city/operation/product when building directories.
+        max_pages: Optional limit of pages to scrape.
+
+    Returns:
+        Dictionary returned by :meth:`LamudiProfessionalScraper.run`.
+    """
+
+    city = product = None
+    operation_type = 'venta'
+
+    if output_path:
+        out = Path(output_path)
+        city = out.parent.parent.name if out.parent.parent.name else None
+        operation_code = out.parent.name.lower()
+        product = out.stem.split('_')[0]
+        op_map = {'ven': 'venta', 'ren': 'renta', 'vnd': 'venta-d', 'vnr': 'venta-r'}
+        operation_type = op_map.get(operation_code, operation_code)
+
+    scraper = LamudiProfessionalScraper(
+        headless=True,
+        max_pages=max_pages,
+        resume_from=1,
+        operation_type=operation_type,
+        city=city,
+        product=product,
+    )
+
+    if url:
+        scraper.base_url = url
+
+    return scraper.run()
+
 def main():
     """Función principal con argumentos de línea de comandos"""
     parser = argparse.ArgumentParser(description='Lamudi Professional Scraper')

--- a/scrapers/lam_det.py
+++ b/scrapers/lam_det.py
@@ -652,6 +652,30 @@ class LamudiUnicoProfessionalScraper:
                 'successful_extractions': self.successful_extractions
             }
 
+def run_scraper(urls_file: str, output_path: str | None = None,
+                max_properties: int = None) -> Dict:
+    """Interface function for orchestrator usage."""
+
+    operation_type = 'venta'
+    if urls_file:
+        name = Path(urls_file).name.upper()
+        if '_REN_' in name:
+            operation_type = 'renta'
+        elif '_VND_' in name:
+            operation_type = 'venta-d'
+        elif '_VNR_' in name:
+            operation_type = 'venta-r'
+
+    scraper = LamudiUnicoProfessionalScraper(
+        urls_file=urls_file,
+        headless=True,
+        max_properties=max_properties,
+        resume_from=0,
+        operation_type=operation_type,
+    )
+
+    return scraper.run()
+
 def main():
     """Función principal con argumentos de línea de comandos"""
     parser = argparse.ArgumentParser(description='Lamudi Unico Professional Scraper')


### PR DESCRIPTION
## Summary
- add `run_scraper` interface for Lamudi base scraper
- implement `run_scraper` for Inmuebles24 and Lamudi detail scrapers
- orchestrator imports scrapers successfully and auto-runs detail scrapers

## Testing
- `python -m py_compile scrapers/lam.py scrapers/inm24_det.py scrapers/lam_det.py`
- `python - <<'PY'
import sys
sys.path.append('orchestrator')
import advanced_orchestrator as ao
print('scrapers_available:', ao.scrapers_available)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68b90252c00c8331b6f93998bc0fefdc