### PR TITLE
feat(prop): allow custom output path

### DIFF
--- a/orchestrator/advanced_orchestrator.py
+++ b/orchestrator/advanced_orchestrator.py
@@ -3,6 +3,8 @@
 Advanced Orchestrator - PropertyScraper Dell710
 Orquestador avanzado con lógica de flujo de trabajo según especificaciones
 Adaptado para trabajar con los archivos CSV individuales ubicados en ``URLs/``
+Cada scraper expone ``run_scraper(url, output_path, ...)`` para permitir al
+orquestador definir la ruta donde se guardan los CSV.
 """
 
 import os
@@ -24,7 +26,7 @@ sys.path.append(str(Path(__file__).parent.parent))
 sys.path.append(str(Path(__file__).parent.parent / 'utils'))
 from enhanced_scraps_registry import EnhancedScrapsRegistry
 
-# Importar scrapers específicos
+# Importar scrapers específicos (todos aceptan ``output_path``)
 try:
     sys.path.append(str(Path(__file__).parent.parent / 'scrapers'))
     from inm24 import run_scraper as run_inmuebles24
@@ -33,7 +35,7 @@ try:
     from mit import run_scraper as run_mitula
     from lam import run_scraper as run_lam
     from lam_det import run_scraper as run_lam_det
-    from prop import run_scraper as run_prop
+    from prop import run_scraper as run_prop  # acepta ``output_path``
     from tro import run_scraper as run_trovit
     scrapers_available = True
 except ImportError as e:

--- a/scrapers/prop.py
+++ b/scrapers/prop.py
@@ -70,7 +70,9 @@ class PropiedadesProfessionalScraper:
     Optimizado para ejecución en Dell T710 Ubuntu Server
     """
     
-    def __init__(self, headless=True, max_pages=None, resume_from=None, operation_type='venta'):
+    def __init__(self, output_path=None, headless=True, max_pages=None,
+                 resume_from=None, operation_type='venta'):
+        self.output_path = output_path
         self.headless = headless
         self.max_pages = max_pages
         self.resume_from = resume_from or 1
@@ -101,6 +103,7 @@ class PropiedadesProfessionalScraper:
         self.errors_count = 0
         
         self.logger.info(f"🚀 Iniciando Propiedades Professional Scraper")
+        self.logger.info(f"   Archivo salida: {output_path}")
         self.logger.info(f"   Operation: {operation_type}")
         self.logger.info(f"   Max pages: {max_pages}")
         self.logger.info(f"   Resume from: {resume_from}")
@@ -477,9 +480,16 @@ class PropiedadesProfessionalScraper:
         # Generar timestamp para archivos
         timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
 
-        # Archivo CSV principal con nueva nomenclatura
-        csv_filename = self.file_name
-        csv_path = self.data_dir / csv_filename
+        # Archivo CSV principal con nueva nomenclatura o ruta proporcionada
+        if self.output_path:
+            csv_path = Path(self.output_path)
+            csv_filename = csv_path.name
+        else:
+            csv_filename = self.file_name
+            csv_path = self.data_dir / csv_filename
+
+        # Asegurar que el directorio exista
+        csv_path.parent.mkdir(parents=True, exist_ok=True)
         
         # Guardar CSV
         with open(csv_path, 'w', newline='', encoding='utf-8') as csvfile:
@@ -622,9 +632,21 @@ def main():
     sys.exit(0 if success else 1)
 
 
-def run_scraper(url: str = None, max_pages: int = None,
-                urls_file: str = None) -> List[Dict]:
-    """Interface function for orchestrator to handle multiple URLs."""
+def run_scraper(url: str = None, output_path: str | None = None,
+                max_pages: int = None, urls_file: str = None) -> List[Dict]:
+    """Interface function for orchestrator to handle multiple URLs.
+
+    Parameters
+    ----------
+    url : str | None
+        URL única a procesar.
+    output_path : str | None
+        Ruta donde se almacenará el CSV resultante.
+    max_pages : int | None
+        Número máximo de páginas a procesar.
+    urls_file : str | None
+        Archivo CSV con URLs a procesar.
+    """
     if url:
         urls = [url]
     else:
@@ -636,6 +658,7 @@ def run_scraper(url: str = None, max_pages: int = None,
     results: List[Dict] = []
     for target in urls:
         scraper = PropiedadesProfessionalScraper(
+            output_path=output_path,
             headless=True,
             max_pages=max_pages,
             resume_from=1,


### PR DESCRIPTION
## Summary
- allow Propiedades scraper to receive an orchestrator-defined output path
- document `output_path` handling in the advanced orchestrator

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b918489ed88331b0f9da4477bc12a8