### PR TITLE
refactor: centralize chromium args for cross-platform scrapers

### DIFF
--- a/scrapers/cyt.py
+++ b/scrapers/cyt.py
@@ -24,6 +24,7 @@ from utils.url_utils import (
     load_urls_for_site,
 )
 from utils.path_builder import build_path
+from utils.browser_config import get_chromium_args
 
 # Selenium imports
 from seleniumbase import SB
@@ -161,27 +162,7 @@ class CasasTerrenosProfessionalScraper:
             'user_agent': random.choice(self.user_agents),
             'locale_code': 'es-MX',
             'timeout': 30,
-            'chromium_arg': [
-                '--no-sandbox',  # Requerido para Ubuntu Server
-                '--disable-dev-shm-usage',  # Evita problemas de memoria compartida
-                '--disable-gpu',  # No usar GPU en headless
-                '--disable-background-timer-throttling',
-                '--disable-backgrounding-occluded-windows',
-                '--disable-renderer-backgrounding',
-                '--disable-extensions',
-                '--disable-plugins',
-                '--disable-sync',
-                '--disable-translate',
-                '--hide-scrollbars',
-                '--mute-audio',
-                '--no-first-run',
-                '--safebrowsing-disable-auto-update',
-                '--ignore-ssl-errors',
-                '--ignore-certificate-errors',
-                '--allow-running-insecure-content',
-                '--disable-web-security',
-                '--disable-features=VizDisplayCompositor',
-            ]
+            'chromium_arg': get_chromium_args()
         }
         
         return sb_config

--- a/scrapers/inm24.py
+++ b/scrapers/inm24.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 import argparse
 from utils.path_builder import build_path
+from utils.browser_config import get_chromium_args
 
 # Selenium imports
 from seleniumbase import SB
@@ -140,28 +141,7 @@ class Inmuebles24ProfessionalScraper:
             'disable_csp': True,  # Deshabilitar Content Security Policy
             'disable_ws': True,  # Deshabilitar web security
             'block_images': False,  # Permitir imágenes para mejor detección
-            'chromium_arg': [
-                '--no-sandbox',  # Requerido para Ubuntu Server
-                '--disable-dev-shm-usage',  # Evita problemas de memoria compartida
-                '--disable-gpu',  # No usar GPU en headless
-                '--disable-background-timer-throttling',
-                '--disable-backgrounding-occluded-windows',
-                '--disable-renderer-backgrounding',
-                '--disable-extensions',
-                '--disable-plugins',
-                '--disable-sync',
-                '--disable-translate',
-                '--hide-scrollbars',
-                '--mute-audio',
-                '--no-first-run',
-                '--safebrowsing-disable-auto-update',
-                '--ignore-ssl-errors',
-                '--ignore-certificate-errors',
-                '--allow-running-insecure-content',
-                '--disable-web-security',
-                '--disable-features=VizDisplayCompositor',
-                '--window-size=1920,1080'
-            ]
+            'chromium_arg': get_chromium_args()
         }
         
         return sb_config

--- a/scrapers/lam.py
+++ b/scrapers/lam.py
@@ -24,6 +24,7 @@ from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.common.exceptions import TimeoutException, NoSuchElementException
 from utils.path_builder import build_path
+from utils.browser_config import get_chromium_args
 
 class LamudiProfessionalScraper:
     """
@@ -132,27 +133,7 @@ class LamudiProfessionalScraper:
             'user_agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
             'locale_code': 'es-MX',
             'timeout': 30,
-            'chromium_arg': [
-                '--no-sandbox',  # Requerido para Ubuntu Server
-                '--disable-dev-shm-usage',  # Evita problemas de memoria compartida
-                '--disable-gpu',  # No usar GPU en headless
-                '--disable-background-timer-throttling',
-                '--disable-backgrounding-occluded-windows',
-                '--disable-renderer-backgrounding',
-                '--disable-extensions',
-                '--disable-plugins',
-                '--disable-sync',
-                '--disable-translate',
-                '--hide-scrollbars',
-                '--mute-audio',
-                '--no-first-run',
-                '--safebrowsing-disable-auto-update',
-                '--ignore-ssl-errors',
-                '--ignore-certificate-errors',
-                '--allow-running-insecure-content',
-                '--disable-web-security',
-                '--disable-features=VizDisplayCompositor',
-            ]
+            'chromium_arg': get_chromium_args()
         }
         
         return sb_config

--- a/scrapers/lam_det.py
+++ b/scrapers/lam_det.py
@@ -23,6 +23,7 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.common.exceptions import TimeoutException, NoSuchElementException
+from utils.browser_config import get_chromium_args
 
 class LamudiUnicoProfessionalScraper:
     """
@@ -183,27 +184,7 @@ class LamudiUnicoProfessionalScraper:
             'user_agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
             'locale_code': 'es-MX',
             'timeout': 30,
-            'chromium_arg': [
-                '--no-sandbox',  # Requerido para Ubuntu Server
-                '--disable-dev-shm-usage',  # Evita problemas de memoria compartida
-                '--disable-gpu',  # No usar GPU en headless
-                '--disable-background-timer-throttling',
-                '--disable-backgrounding-occluded-windows',
-                '--disable-renderer-backgrounding',
-                '--disable-extensions',
-                '--disable-plugins',
-                '--disable-sync',
-                '--disable-translate',
-                '--hide-scrollbars',
-                '--mute-audio',
-                '--no-first-run',
-                '--safebrowsing-disable-auto-update',
-                '--ignore-ssl-errors',
-                '--ignore-certificate-errors',
-                '--allow-running-insecure-content',
-                '--disable-web-security',
-                '--disable-features=VizDisplayCompositor',
-            ]
+            'chromium_arg': get_chromium_args()
         }
         
         return sb_config

--- a/scrapers/mit.py
+++ b/scrapers/mit.py
@@ -25,6 +25,7 @@ from utils.url_utils import (
     load_urls_for_site,
 )
 from utils.path_builder import build_path
+from utils.browser_config import get_chromium_args
 
 # Selenium imports
 from seleniumbase import SB
@@ -155,27 +156,7 @@ class MitulaProfessionalScraper:
             'user_agent': random.choice(self.user_agents),
             'locale_code': 'es-MX',
             'timeout': 30,
-            'chromium_arg': [
-                '--no-sandbox',  # Requerido para Ubuntu Server
-                '--disable-dev-shm-usage',  # Evita problemas de memoria compartida
-                '--disable-gpu',  # No usar GPU en headless
-                '--disable-background-timer-throttling',
-                '--disable-backgrounding-occluded-windows',
-                '--disable-renderer-backgrounding',
-                '--disable-extensions',
-                '--disable-plugins',
-                '--disable-sync',
-                '--disable-translate',
-                '--hide-scrollbars',
-                '--mute-audio',
-                '--no-first-run',
-                '--safebrowsing-disable-auto-update',
-                '--ignore-ssl-errors',
-                '--ignore-certificate-errors',
-                '--allow-running-insecure-content',
-                '--disable-web-security',
-                '--disable-features=VizDisplayCompositor',
-            ]
+            'chromium_arg': get_chromium_args()
         }
         
         return sb_config

--- a/scrapers/prop.py
+++ b/scrapers/prop.py
@@ -18,6 +18,7 @@ import argparse
 
 from utils.url_utils import extract_url_column, load_urls_from_csv
 from utils.path_builder import build_path
+from utils.browser_config import get_chromium_args
 
 # Selenium imports
 from seleniumbase import SB
@@ -129,27 +130,7 @@ class PropiedadesProfessionalScraper:
             'user_agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
             'locale_code': 'es-MX',
             'timeout': 30,
-            'chromium_arg': [
-                '--no-sandbox',  # Requerido para Ubuntu Server
-                '--disable-dev-shm-usage',  # Evita problemas de memoria compartida
-                '--disable-gpu',  # No usar GPU en headless
-                '--disable-background-timer-throttling',
-                '--disable-backgrounding-occluded-windows',
-                '--disable-renderer-backgrounding',
-                '--disable-extensions',
-                '--disable-plugins',
-                '--disable-sync',
-                '--disable-translate',
-                '--hide-scrollbars',
-                '--mute-audio',
-                '--no-first-run',
-                '--safebrowsing-disable-auto-update',
-                '--ignore-ssl-errors',
-                '--ignore-certificate-errors',
-                '--allow-running-insecure-content',
-                '--disable-web-security',
-                '--disable-features=VizDisplayCompositor',
-            ]
+            'chromium_arg': get_chromium_args()
         }
         
         return sb_config

--- a/scrapers/tro.py
+++ b/scrapers/tro.py
@@ -25,6 +25,7 @@ from utils.url_utils import (
     load_urls_for_site,
 )
 from utils.path_builder import build_path
+from utils.browser_config import get_chromium_args
 
 # Selenium imports
 from seleniumbase import SB
@@ -147,48 +148,7 @@ class TrovitProfessionalScraper:
             'disable_csp': True,  # Deshabilitar Content Security Policy
             'disable_ws': True,  # Deshabilitar web security
             'block_images': False,  # Permitir imágenes para mejor detección
-            'chromium_arg': [
-                '--no-sandbox',  # Requerido para Ubuntu Server
-                '--disable-dev-shm-usage',  # Evita problemas de memoria compartida
-                '--disable-gpu',  # No usar GPU en headless
-                '--disable-background-timer-throttling',
-                '--disable-backgrounding-occluded-windows',
-                '--disable-renderer-backgrounding',
-                '--disable-extensions',
-                '--disable-plugins',
-                '--disable-sync',
-                '--disable-translate',
-                '--hide-scrollbars',
-                '--mute-audio',
-                '--no-first-run',
-                '--safebrowsing-disable-auto-update',
-                '--ignore-ssl-errors',
-                '--ignore-certificate-errors',
-                '--allow-running-insecure-content',
-                '--disable-web-security',
-                '--disable-features=VizDisplayCompositor',
-            ],
-            'chromium_arg': [
-                '--no-sandbox',  # Requerido para Ubuntu Server
-                '--disable-dev-shm-usage',  # Evita problemas de memoria compartida
-                '--disable-gpu',  # No usar GPU en headless
-                '--disable-background-timer-throttling',
-                '--disable-backgrounding-occluded-windows',
-                '--disable-renderer-backgrounding',
-                '--disable-extensions',
-                '--disable-plugins',
-                '--disable-sync',
-                '--disable-translate',
-                '--hide-scrollbars',
-                '--mute-audio',
-                '--no-first-run',
-                '--safebrowsing-disable-auto-update',
-                '--ignore-ssl-errors',
-                '--ignore-certificate-errors',
-                '--allow-running-insecure-content',
-                '--disable-web-security',
-                '--disable-features=VizDisplayCompositor',
-            ]
+            'chromium_arg': get_chromium_args()
         }
         
         return sb_config

--- a/utils/browser_config.py
+++ b/utils/browser_config.py
@@ -1,0 +1,48 @@
+import sys
+from typing import List
+
+
+def get_chromium_args() -> List[str]:
+    """Return a list of Chromium args depending on the platform.
+
+    Ensures headless mode works across Linux and Windows 11 terminals.
+    """
+    if sys.platform.startswith("win"):
+        return [
+            "--disable-gpu",
+            "--disable-extensions",
+            "--disable-sync",
+            "--disable-translate",
+            "--hide-scrollbars",
+            "--mute-audio",
+            "--no-first-run",
+            "--safebrowsing-disable-auto-update",
+            "--ignore-ssl-errors",
+            "--ignore-certificate-errors",
+            "--allow-running-insecure-content",
+            "--disable-web-security",
+            "--disable-features=VizDisplayCompositor",
+            "--window-size=1920,1080",
+        ]
+
+    return [
+        "--no-sandbox",
+        "--disable-dev-shm-usage",
+        "--disable-gpu",
+        "--disable-background-timer-throttling",
+        "--disable-backgrounding-occluded-windows",
+        "--disable-renderer-backgrounding",
+        "--disable-extensions",
+        "--disable-plugins",
+        "--disable-sync",
+        "--disable-translate",
+        "--hide-scrollbars",
+        "--mute-audio",
+        "--no-first-run",
+        "--safebrowsing-disable-auto-update",
+        "--ignore-ssl-errors",
+        "--ignore-certificate-errors",
+        "--allow-running-insecure-content",
+        "--disable-web-security",
+        "--disable-features=VizDisplayCompositor",
+    ]


### PR DESCRIPTION
## Summary
- add `utils/browser_config.get_chromium_args` to tailor Chromium flags for Linux vs. Windows
- simplify scraper drivers by using the shared utility

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b91b3731588331b9e3e1ff47fc6dba